### PR TITLE
Prevent 1.31 installations from loading

### DIFF
--- a/HiveWE/HiveWE.cpp
+++ b/HiveWE/HiveWE.cpp
@@ -19,7 +19,7 @@ HiveWE::HiveWE(QWidget* parent) : QMainWindow(parent) {
 	setAutoFillBackground(true);
 
 	fs::path directory = find_warcraft_directory();
-	while (!fs::exists(directory / "Data") || directory == "") {
+	while (!fs::exists(directory / "Data") || directory == "" || fs::exists(directory / "x86_64")) {
 		directory = QFileDialog::getExistingDirectory(this, "Select Warcraft Directory", "/home", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks).toStdWString();
 		if (directory == "") {
 			exit(EXIT_SUCCESS);
@@ -257,7 +257,7 @@ void HiveWE::switch_warcraft() {
 		directory = QFileDialog::getExistingDirectory(this, "Select Warcraft Directory", "/home", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks).toStdWString();
 		if (directory == "")
 			directory = hierarchy.warcraft_directory;
-	} while (!fs::exists(directory / "Data"));
+	} while (!fs::exists(directory / "Data") || fs::exists(directory / "x86_64"));
 	QSettings settings;
 	settings.setValue("warcraftDirectory", QString::fromStdString(directory.string()));
 


### PR DESCRIPTION
The file structure in CASC changed too much to maintain compatibility between 1.30 and 1.31 (without a lot of ifs and some variables) so to prevent crashes 1.31 shouldn't be loadable for now. A beta of 1.31 compatible HiveWE can be found [here](https://github.com/BogdanW3/HiveWE/tree/31).