### PR TITLE
Handle incorrect gamedirs more gracefully

### DIFF
--- a/src/Base/Hierarchy.cpp
+++ b/src/Base/Hierarchy.cpp
@@ -11,7 +11,7 @@ using namespace std::literals::string_literals;
 
 Hierarchy hierarchy;
 
-void Hierarchy::open_casc(fs::path directory) {
+bool Hierarchy::open_casc(fs::path directory) {
 	warcraft_directory = directory;
 	QSettings settings;
 	ptr = settings.value("flavour", "Retail").toString() != "Retail";
@@ -21,9 +21,10 @@ void Hierarchy::open_casc(fs::path directory) {
 	local_files = war3reg.value("Allow Local Files", 0).toInt() != 0;
 
 	std::cout << "Loading CASC data from: " << warcraft_directory << "\n";
-	game_data.open(warcraft_directory / (ptr ? ":w3t" : ":w3"));
+	bool open = game_data.open(warcraft_directory / (ptr ? ":w3t" : ":w3"));
 	root_directory = warcraft_directory / (ptr ? "_ptr_" : "_retail_");
-	aliases.load("filealiases.json");
+	if (open) aliases.load("filealiases.json");
+	return open;
 }
 
 BinaryReader Hierarchy::open_file(const fs::path& path) const {

--- a/src/Base/Hierarchy.h
+++ b/src/Base/Hierarchy.h
@@ -24,7 +24,7 @@ public:
 	bool teen;
 	bool local_files;
 
-	void open_casc(fs::path directory);
+	bool open_casc(fs::path directory);
 
 	BinaryReader open_file(const fs::path& path) const;
 	bool file_exists(const fs::path& path) const;

--- a/src/File Formats/CASC.cpp
+++ b/src/File Formats/CASC.cpp
@@ -40,11 +40,13 @@ namespace casc {
 		close();
 	}
 
-	void CASC::open(const fs::path& path) {
+	bool CASC::open(const fs::path& path) {
+		if (handle != nullptr) close();
 		const bool opened = CascOpenStorage(path.c_str(), CASC_LOCALE_ALL, &handle);
 		if (!opened) {
 			fmt::print("Error opening {} with error: {}\n", path.string(), GetLastError());
 		}
+		return opened;
 	}
 
 	File CASC::file_open(const fs::path& path) const {

--- a/src/File Formats/CASC.h
+++ b/src/File Formats/CASC.h
@@ -60,7 +60,7 @@ namespace casc {
 			return *this;
 		}
 
-		void open(const fs::path& path);
+		bool open(const fs::path& path);
 		void close();
 
 		File file_open(const fs::path& path) const;


### PR DESCRIPTION
By moving the hierarchy open function into the while loop, this commit attempts to detect when opening the CASC fails so the user is allowed to change the game directory to a correct one (if the game directory detected is 1.31 or other errors happen). This also helps against error 32 by letting the user choose the same folder after closing the game or WE (sharing violation stuff).