### PR TITLE
Fixes

### DIFF
--- a/Data/Shaders/static_mesh_instanced_hd.fs
+++ b/Data/Shaders/static_mesh_instanced_hd.fs
@@ -23,7 +23,7 @@ void main() {
 		vec3 emissive_texel = texture(emissive, UV).rgb;
 		vec4 orm_texel = texture(orm, UV);
 		vec3 tc_texel = texture(teamColor, UV).rgb;
-		//color.rgb = (color.rgb * (1 - orm_texel.w) + color.rgb * tc_texel * orm_texel.w);
+		color.rgb = (color.rgb * (1 - orm_texel.w) + color.rgb * tc_texel * orm_texel.w);
 
 		// normal is a 2 channel normal map so we have to deduce the 3rd value
 		vec2 normal_texel = texture(normal, UV).xy * 2.0 - 1.0;

--- a/src/Base/Doodads.cpp
+++ b/src/Base/Doodads.cpp
@@ -456,7 +456,7 @@ std::shared_ptr<StaticMesh> Doodads::get_mesh(std::string id, int variation) {
 
 	if (replace_texture) {
 		replaceable_texture = mdx::replacable_id_to_texture[std::stoi(replaceable_id)];
-		mdx::replacable_id_to_texture[std::stoi(replaceable_id)] = texture_name.string() + (hierarchy.hd ? "_diffuse.dds" : ".dds");
+		mdx::replacable_id_to_texture[std::stoi(replaceable_id)] = texture_name.string();
 	}
 
 	id_to_mesh.emplace(full_id, resource_manager.load<StaticMesh>(mesh_path, replace_texture ? texture_name.string() : ""));

--- a/src/Base/Map.cpp
+++ b/src/Base/Map.cpp
@@ -227,7 +227,9 @@ void Map::load(const fs::path& path) {
 	begin = std::chrono::steady_clock::now();
 
 	// Pathing Map
-	pathing_map.load();
+	if (hierarchy.map_file_exists("war3map.wpm")) {
+		pathing_map.load();
+	}
 
 	std::cout << "Pathing loading: " << (std::chrono::steady_clock::now() - begin).count() / 1'000'000 << "ms\n";
 	begin = std::chrono::steady_clock::now();

--- a/src/Base/MapInfo.cpp
+++ b/src/Base/MapInfo.cpp
@@ -12,17 +12,20 @@ void MapInfo::load() {
 
 	const int version = reader.read<uint32_t>();
 
-	if (version != 18 && version != 25 && version != 28 && version != 31) {
+	if (version != 31 && version != 28 && version != 25 && version != 18 && version != 15) {
 		std::cout << "Unknown war3map.w3i version\n";
 	}
 
-	map_version = reader.read<uint32_t>();
-	editor_version = reader.read<uint32_t>();
-	if (version >= 28) {
-		game_version_major = reader.read<uint32_t>();
-		game_version_minor = reader.read<uint32_t>();
-		game_version_patch = reader.read<uint32_t>();
-		game_version_build = reader.read<uint32_t>();
+	if (version >= 18) {
+		map_version = reader.read<uint32_t>();
+		editor_version = reader.read<uint32_t>();
+
+		if (version >= 28) {
+			game_version_major = reader.read<uint32_t>();
+			game_version_minor = reader.read<uint32_t>();
+			game_version_patch = reader.read<uint32_t>();
+			game_version_build = reader.read<uint32_t>();
+		}
 	}
 	name = reader.read_c_string();
 	author = reader.read_c_string();
@@ -108,7 +111,14 @@ void MapInfo::load() {
 		prologue_text = reader.read_c_string();
 		prologue_title = reader.read_c_string();
 		prologue_subtitle = reader.read_c_string();
+	} else {
+		reader.advance(1); //unknown, loading screen number but only 1 digit?
+		loading_screen_text = reader.read_c_string();
+		loading_screen_title = reader.read_c_string();
+		loading_screen_subtitle = reader.read_c_string();
+		reader.advance(4); //prologue stuff?
 	}
+
 	players.resize(reader.read<uint32_t>());
 	for (auto&& i : players) {
 		i.internal_number = reader.read<uint32_t>();
@@ -138,6 +148,10 @@ void MapInfo::load() {
 		i.name = reader.read_c_string();
 	}
 
+	if (reader.remaining() < 4) {
+		return;
+	}
+
 	available_upgrades.resize(reader.read<uint32_t>());
 	for (auto&& i : available_upgrades) {
 		i.player_flags = reader.read<uint32_t>();
@@ -146,10 +160,18 @@ void MapInfo::load() {
 		i.availability = reader.read<uint32_t>();
 	}
 
+	if (reader.remaining() < 4) {
+		return;
+	}
+
 	available_tech.resize(reader.read<uint32_t>());
 	for (auto&& i : available_tech) {
 		i.player_flags = reader.read<uint32_t>();
 		i.id = reader.read_string(4);
+	}
+
+	if (reader.remaining() < 4) {
+		return;
 	}
 
 	random_unit_tables.resize(reader.read<uint32_t>());
@@ -165,6 +187,10 @@ void MapInfo::load() {
 				j.ids.push_back(reader.read_string(4));
 			}
 		}
+	}
+
+	if (reader.remaining() < 4) {
+		return;
 	}
 
 	if (version >= 25) {

--- a/src/Base/Terrain.cpp
+++ b/src/Base/Terrain.cpp
@@ -175,7 +175,7 @@ void Terrain::create() {
 	// Ground textures
 	for (const auto& tile_id : tileset_ids) {
 		ground_textures.push_back(resource_manager.load<GroundTexture>(terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id)));
-		ground_texture_to_id.emplace(tile_id, ground_textures.size() - 1);
+		ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
 	}
 	blight_texture = static_cast<int>(ground_textures.size());
 	ground_texture_to_id.emplace("blight", blight_texture);
@@ -183,7 +183,7 @@ void Terrain::create() {
 
 	// Cliff Textures
 	for (auto&& cliff_id : cliffset_ids) {
-		cliff_textures.push_back(resource_manager.load<Texture>(cliff_slk.data("texdir", cliff_id) + "/" + cliff_slk.data("texfile", cliff_id)));
+		cliff_textures.push_back(resource_manager.load<Texture>(cliff_slk.data("texdir", cliff_id) + "/" + cliff_slk.data("texfile", cliff_id) + (hierarchy.hd ? "_diffuse.dds" : ".dds")));
 		cliff_texture_size = std::max(cliff_texture_size, cliff_textures.back()->width);
 		cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data("groundtile", cliff_id)]);
 	}
@@ -447,7 +447,7 @@ void Terrain::change_tileset(const std::vector<std::string>& new_tileset_ids, st
 
 	for (const auto& tile_id : tileset_ids) {
 		ground_textures.push_back(resource_manager.load<GroundTexture>(terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id) + (hierarchy.hd ? "_diffuse.dds" : ".dds")));
-		ground_texture_to_id.emplace(tile_id, ground_textures.size() - 1);
+		ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
 	}
 	blight_texture = static_cast<int>(ground_textures.size());
 	ground_texture_to_id.emplace("blight", blight_texture);

--- a/src/Base/Triggers.h
+++ b/src/Base/Triggers.h
@@ -8,23 +8,23 @@
 #include "BinaryReader.h"
 #include "BinaryWriter.h"
 
-struct TriggerCategory {
-	int id;
-	std::string name;
-	uint32_t unknown;
-	bool is_comment = false;
-	int parent_id;
+enum class Classifier
+{
+	map = 1,
+	library = 2,
+	category = 4,
+	gui = 8,
+	comment = 16,
+	script = 32,
+	variable = 64
 };
 
-struct TriggerVariable {
-	std::string name;
-	std::string type;
-	uint32_t unknown;
-	bool is_array;
-	int array_size = 0;
-	bool is_initialized;
-	std::string initial_value;
+struct TriggerCategory {
+	Classifier classifier;
 	int id;
+	std::string name;
+	bool open_state = true;
+	bool is_comment = false;
 	int parent_id;
 };
 
@@ -75,14 +75,6 @@ struct ECA {
 	std::vector<ECA> ecas;
 };
 
-enum class Classifier {
-	category = 4,
-	gui = 8,
-	comment = 16,
-	script = 32,
-	variable = 64
-};
-
 struct Trigger {
 	Classifier classifier;
 	int id;
@@ -100,6 +92,18 @@ struct Trigger {
 	static inline int next_id = 0;
 };
 
+struct TriggerVariable {
+	std::string name;
+	std::string type;
+	uint32_t unknown;
+	bool is_array;
+	int array_size = 0;
+	bool is_initialized;
+	std::string initial_value;
+	int id;
+	int parent_id;
+};
+
 class Triggers {
 	std::unordered_map<std::string, int> argument_counts;
 	const std::string separator = "//===========================================================================\n";
@@ -108,20 +112,17 @@ class Triggers {
 	static constexpr int write_sub_version = 7;
 	static constexpr int write_string_version = 1;
 
+	int map_count = 0;
+	int library_count = 0;
+	int category_count = 0;
+	int trigger_count = 0;
+	int comment_count = 0;
+	int script_count = 0;
+	int variable_count = 0;
+
 	int unknown1 = 0;
 	int unknown2 = 0;
-	int unknown3 = 0;
-	int unknown4 = 0;
-
-	int unknown5 = 0;
-	int unknown6 = 0;
-	int unknown7 = 0;
-	int unknown8 = 0;
-	int unknown9 = 0;
-
-	int unknown10 = 0;
-	int unknown11 = 0;
-	int unknown12 = 0;
+	int trig_def_ver = 2;
 
 	void parse_parameter_structure(BinaryReader& reader, TriggerParameter& parameter, uint32_t version);
 	void parse_eca_structure(BinaryReader& reader, ECA& eca, bool is_child, uint32_t version);

--- a/src/File Formats/JSON.cpp
+++ b/src/File Formats/JSON.cpp
@@ -58,7 +58,8 @@ namespace json {
 	bool JSON::exists(const std::string& file) const {
 		std::string file_lower_case = file;
 		std::transform(file_lower_case.begin(), file_lower_case.end(), file_lower_case.begin(), ::tolower);
-
+		std::transform(file_lower_case.begin(), file_lower_case.end(), file_lower_case.begin(),
+			[](char c) {if (c == '/')return '\\'; return c; });
 		if (json_data.contains(file_lower_case)) {
 			return true;
 		}
@@ -68,6 +69,8 @@ namespace json {
 	std::string JSON::alias(const std::string& file) const {
 		std::string file_lower_case = file;
 		std::transform(file_lower_case.begin(), file_lower_case.end(), file_lower_case.begin(), ::tolower);
+		std::transform(file_lower_case.begin(), file_lower_case.end(), file_lower_case.begin(),
+					   [](char c) {if (c == '/')return '\\'; return c; });
 		return json_data.at(file_lower_case);
 	}
 }

--- a/src/File Formats/MDX.cpp
+++ b/src/File Formats/MDX.cpp
@@ -1331,11 +1331,15 @@ namespace mdx {
 				case ChunkTag::CORN:
 					read_CORN_chunk(reader);
 					break;
-				case ChunkTag::FAFX:
-					reader.advance(4);
-					face_target = reader.read_string(80);
-					face_path = reader.read_string(260);
+				case ChunkTag::FAFX: {
+					int size = reader.read<uint32_t>();
+					while (size > 0) {
+						face_target = reader.read_string(80);
+						face_path = reader.read_string(260);
+						size -= 340;
+					}
 					break;
+				}
 				case ChunkTag::CAMS:
 					read_CAMS_chunk(reader);
 					break;

--- a/src/File Formats/MDX.cpp
+++ b/src/File Formats/MDX.cpp
@@ -7,16 +7,16 @@
 
 namespace mdx {
 	std::unordered_map<int, std::string> replacable_id_to_texture{
-		{ 1, "ReplaceableTextures/TeamColor/TeamColor00.dds" },
-		{ 2, "ReplaceableTextures/TeamGlow/TeamGlow00.dds" },
-		{ 11, "ReplaceableTextures/Cliff/Cliff0.dds" },
-		{ 31, "ReplaceableTextures/LordaeronTree/LordaeronFallTree.dds" },
-		{ 32, "ReplaceableTextures/AshenvaleTree/AshenTree.dds" },
-		{ 33, "ReplaceableTextures/BarrensTree/BarrensTree.dds" },
-		{ 34, "ReplaceableTextures/NorthrendTree/NorthTree.dds" },
-		{ 35, "ReplaceableTextures/Mushroom/MushroomTree.dds" },
-		{ 36, "ReplaceableTextures/RuinsTree/RuinsTree.dds" },
-		{ 37, "ReplaceableTextures/OutlandMushroomTree/MushroomTree.dds" }
+		{ 1, "ReplaceableTextures/TeamColor/TeamColor00" },
+		{ 2, "ReplaceableTextures/TeamGlow/TeamGlow00" },
+		{ 11, "ReplaceableTextures/Cliff/Cliff0" },
+		{ 31, "ReplaceableTextures/LordaeronTree/LordaeronFallTree" },
+		{ 32, "ReplaceableTextures/AshenvaleTree/AshenTree" },
+		{ 33, "ReplaceableTextures/BarrensTree/BarrensTree" },
+		{ 34, "ReplaceableTextures/NorthrendTree/NorthTree" },
+		{ 35, "ReplaceableTextures/Mushroom/MushroomTree" },
+		{ 36, "ReplaceableTextures/RuinsTree/RuinsTree" },
+		{ 37, "ReplaceableTextures/OutlandMushroomTree/MushroomTree" }
 	};
 
 	Extent::Extent(BinaryReader& reader) {
@@ -165,6 +165,8 @@ namespace mdx {
 			for (size_t i = 0; i < layers_count; i++) {
 				const size_t reader_pos = reader.position;
 				Layer layer;
+				if (material.shader_name == "Shader_HD_DefaultUnit")
+					layer.type = (LayerType)i;
 				const uint32_t size = reader.read<uint32_t>();
 				layer.blend_mode = reader.read<uint32_t>();
 				layer.shading_flags = reader.read<uint32_t>();
@@ -271,7 +273,7 @@ namespace mdx {
 			texture.replaceable_id = reader.read<uint32_t>();
 			texture.file_name = reader.read_string(260);
 			texture.flags = reader.read<uint32_t>();
-			textures.push_back(std::move(texture));
+			textures[i] = texture;
 		}
 	}
 
@@ -832,7 +834,8 @@ namespace mdx {
 
 		writer.write(ChunkTag::TEXS);
 		writer.write<uint32_t>(textures.size() * 268);
-		for (const auto& texture : textures) {
+		for (auto const& texturepair : textures) {
+			Texture texture = texturepair.second;
 			writer.write<uint32_t>(texture.replaceable_id);
 			writer.write_c_string_padded(texture.file_name.string(), 260);
 			writer.write<uint32_t>(texture.flags);

--- a/src/File Formats/MDX.h
+++ b/src/File Formats/MDX.h
@@ -151,7 +151,19 @@ namespace mdx {
 		}
 	};
 
+	enum class LayerType {
+		DEFAULT = -1,
+		DIFFUSE = 0,
+		NORMAL = 1,
+		ORM = 2,
+		EMISSIVE = 3,
+		TEAM_COLOR = 4,
+		ENVIRONMENT = 5
+	};
+
 	struct Layer {
+
+		LayerType type = LayerType::DEFAULT;
 		uint32_t blend_mode;
 		uint32_t shading_flags;
 		uint32_t texture_id;
@@ -612,7 +624,7 @@ namespace mdx {
 		std::vector<GeosetAnimation> animations;
 		std::vector<Bone> bones;
 		std::vector<Material> materials;
-		std::vector<Texture> textures;
+		std::unordered_map<int, Texture> textures;
 		std::vector<Light> lights;
 		std::vector<Node> help_bones;
 		std::vector<Attachment> attachments;

--- a/src/File Formats/SLK.cpp
+++ b/src/File Formats/SLK.cpp
@@ -180,7 +180,11 @@ namespace slk {
 	/// If an unknown column key is encountered then the column is added
 	void SLK::merge(const ini::INI& ini, const SLK& meta_slk) {
 		for (const auto& [section_key, section_value] : ini.ini_data) {
-			if (!base_data.contains(section_key)) {
+			std::string section_key_temp = section_key;
+			if (section_key_temp == "YTsc") {
+				section_key_temp = "Ytsc";
+			}
+			if (!base_data.contains(section_key_temp)) {
 				continue;
 			}
 
@@ -202,8 +206,8 @@ namespace slk {
 					|| key_lower == "unbuttonpos" 
 					|| key_lower == "researchbuttonpos") && column_headers.contains(key_lower + "2")) {
 
-					base_data[section_key][key_lower] = value[0];
-					base_data[section_key][key_lower + "2"] = value[1];
+					base_data[section_key_temp][key_lower] = value[0];
+					base_data[section_key_temp][key_lower + "2"] = value[1];
 					continue;
 				}
 				
@@ -232,14 +236,14 @@ namespace slk {
 						if (!column_headers.contains(new_key)) {
 							add_column(new_key);
 						}
-						base_data[section_key][new_key] = value[i];
+						base_data[section_key_temp][new_key] = value[i];
 					}
 					continue;
 				} else {
 					if (meta_slk.data<std::string>("type", id).ends_with("List")) {
-						base_data[section_key][key_lower] = absl::StrJoin(value, ",");
+						base_data[section_key_temp][key_lower] = absl::StrJoin(value, ",");
 					} else {
-						base_data[section_key][key_lower] = value[0];
+						base_data[section_key_temp][key_lower] = value[0];
 					
 					}
 				}

--- a/src/Resources/GPUTexture.cpp
+++ b/src/Resources/GPUTexture.cpp
@@ -9,14 +9,10 @@
 GPUTexture::GPUTexture(const fs::path& path) {
 	fs::path new_path = path;
 
-	if (hierarchy.hd) {
-		new_path.replace_filename(path.stem().string() + "_diffuse.dds");
-	}
 	if (!hierarchy.file_exists(new_path)) {
-		new_path = path;
-		new_path.replace_extension(".blp");
+		new_path.replace_extension(".dds");
 		if (!hierarchy.file_exists(new_path)) {
-			new_path.replace_extension(".dds");
+			new_path.replace_extension(".blp");
 			if (!hierarchy.file_exists(new_path)) {
 				std::cout << "Error loading texture " << new_path << "\n";
 				new_path = "Textures/btntempw.dds";

--- a/src/Resources/SkinnedMesh.h
+++ b/src/Resources/SkinnedMesh.h
@@ -48,7 +48,7 @@ class SkinnedMesh : public Resource {
 
 	fs::path path;
 //	int mesh_id;
-	std::vector<std::shared_ptr<GPUTexture>> textures;
+	std::unordered_map<int, std::shared_ptr<GPUTexture>> textures;
 	std::vector<glm::mat4> render_jobs;
 	std::vector<glm::vec3> render_colors;
 	std::vector<const SkeletalModelInstance*> skeletons;
@@ -59,6 +59,7 @@ class SkinnedMesh : public Resource {
 	explicit SkinnedMesh(const fs::path& path);
 	virtual ~SkinnedMesh();
 
+	const std::string typeToSuffix(mdx::LayerType type);
 	void render_queue(const SkeletalModelInstance& skeleton, glm::vec3 color);
 	void render_color_coded(const SkeletalModelInstance& skeleton, int id);
 

--- a/src/Resources/StaticMesh.cpp
+++ b/src/Resources/StaticMesh.cpp
@@ -5,6 +5,21 @@
 
 #include "HiveWE.h"
 
+const std::string StaticMesh::typeToSuffix(mdx::LayerType type) {
+	switch (type) {
+		case mdx::LayerType::DIFFUSE:
+			return "_diffuse.dds";
+		case mdx::LayerType::NORMAL:
+			return "_normal.dds";
+		case mdx::LayerType::ORM:
+			return "_orm.dds";
+		case mdx::LayerType::EMISSIVE:
+			return "_emissive.dds";
+		default:
+			return ".dds";
+	}
+}
+
 StaticMesh::StaticMesh(const fs::path& path) {
 	if (path.extension() != ".mdx" && path.extension() != ".MDX") {
 		throw;
@@ -90,18 +105,25 @@ StaticMesh::StaticMesh(const fs::path& path) {
 		extent = model.sequences.front().extent;
 	}
 
-	for (const auto& i : model.textures) {
-		if (i.replaceable_id != 0) {
-			if (!mdx::replacable_id_to_texture.contains(i.replaceable_id)) {
-				std::cout << "Unknown replaceable ID found\n";
+	for (const auto& i : model.materials) {
+		for (const auto& j : i.layers) {
+			auto tex = model.textures[j.texture_id];
+			if (tex.replaceable_id != 0) {
+				if (!mdx::replacable_id_to_texture.contains(tex.replaceable_id)) {
+						std::cout << "Unknown replaceable ID found\n";
+				}
+				textures[j.texture_id] = resource_manager.load<GPUTexture>(
+					mdx::replacable_id_to_texture[tex.replaceable_id] + typeToSuffix(j.type),
+					(tex.flags & 1) ? "W" : "");
+			} else {
+				textures[j.texture_id] = resource_manager.load<GPUTexture>(tex.file_name,
+					(tex.flags & 1) ? "W" : "");
 			}
-			textures.push_back(resource_manager.load<GPUTexture>(mdx::replacable_id_to_texture[i.replaceable_id]));
-		} else {
-			textures.push_back(resource_manager.load<GPUTexture>(i.file_name));
 
-			// ToDo Same texture on different model with different flags?
-			gl->glTextureParameteri(textures.back()->id, GL_TEXTURE_WRAP_S, i.flags & 1 ? GL_REPEAT : GL_CLAMP_TO_EDGE);
-			gl->glTextureParameteri(textures.back()->id, GL_TEXTURE_WRAP_T, i.flags & 1 ? GL_REPEAT : GL_CLAMP_TO_EDGE);
+			gl->glTextureParameteri(textures[j.texture_id]->id, GL_TEXTURE_WRAP_S,
+									(tex.flags & 1) ? GL_REPEAT : GL_CLAMP_TO_EDGE);
+			gl->glTextureParameteri(textures[j.texture_id]->id, GL_TEXTURE_WRAP_T,
+									(tex.flags & 1) ? GL_REPEAT : GL_CLAMP_TO_EDGE);
 		}
 	}
 
@@ -240,7 +262,7 @@ void StaticMesh::render_opaque_sd() const {
 				gl->glDepthMask(true);
 			}
 
-			gl->glBindTextureUnit(0, textures[j.texture_id]->id);
+			gl->glBindTextureUnit(0, textures.at(j.texture_id)->id);
 			gl->glDrawElementsInstancedBaseVertex(GL_TRIANGLES, i.indices, GL_UNSIGNED_SHORT, reinterpret_cast<void*>(i.base_index * sizeof(uint16_t)), render_jobs.size(), i.base_vertex);
 		}
 	}
@@ -283,7 +305,7 @@ void StaticMesh::render_opaque_hd() const {
 		}
 
 		for (short i = 0; i < 6; i++)
-			gl->glBindTextureUnit(i, textures[layers[i].texture_id]->id);
+			gl->glBindTextureUnit(i, textures.at(layers[i].texture_id)->id);
 
 		gl->glDrawElementsInstancedBaseVertex(GL_TRIANGLES, i.indices, GL_UNSIGNED_SHORT, reinterpret_cast<void*>(i.base_index * sizeof(uint16_t)), render_jobs.size(), i.base_vertex);
 	}
@@ -353,7 +375,7 @@ void StaticMesh::render_transparent_sd(int instance_id) const {
 				gl->glDepthMask(true);
 			}
 
-			gl->glBindTextureUnit(0, textures[j.texture_id]->id);
+			gl->glBindTextureUnit(0, textures.at(j.texture_id)->id);
 
 			gl->glDrawElementsBaseVertex(GL_TRIANGLES, i.indices, GL_UNSIGNED_SHORT, reinterpret_cast<void*>(i.base_index * sizeof(uint16_t)), i.base_vertex);
 		}
@@ -417,7 +439,7 @@ void StaticMesh::render_transparent_hd(int instance_id) const {
 		}
 
 		for (short i = 0; i < 6; i++)
-			gl->glBindTextureUnit(i, textures[layers[i].texture_id]->id);
+			gl->glBindTextureUnit(i, textures.at(layers[i].texture_id)->id);
 
 		gl->glDrawElementsBaseVertex(GL_TRIANGLES, i.indices, GL_UNSIGNED_SHORT, reinterpret_cast<void*>(i.base_index * sizeof(uint16_t)), i.base_vertex);
 	}

--- a/src/Resources/StaticMesh.h
+++ b/src/Resources/StaticMesh.h
@@ -36,7 +36,7 @@ public:
 	GLuint color_buffer;
 
 	fs::path path;
-	std::vector<std::shared_ptr<GPUTexture>> textures;
+	std::unordered_map<int, std::shared_ptr<GPUTexture>> textures;
 	std::vector<mdx::Material> materials;
 	std::vector<glm::mat4> render_jobs;
 	std::vector<glm::vec3> render_colors;
@@ -46,6 +46,7 @@ public:
 	explicit StaticMesh(const fs::path& path);
 	virtual ~StaticMesh();
 
+	const std::string typeToSuffix(mdx::LayerType type);
 	void render_queue(const glm::mat4& model, glm::vec3 color);
 
 	void render_opaque_sd() const;

--- a/src/Resources/Texture.cpp
+++ b/src/Resources/Texture.cpp
@@ -9,14 +9,14 @@
 Texture::Texture(const fs::path& path) {
 	fs::path new_path = path;
 
-	if (hierarchy.hd) {
-		new_path.replace_filename(path.stem().string() + "_diffuse.dds");
-	}
 	if (!hierarchy.file_exists(new_path)) {
 		new_path = path;
-		new_path.replace_extension(".blp");
+		new_path.replace_extension(".dds");
 		if (!hierarchy.file_exists(new_path)) {
-			new_path.replace_extension(".dds");
+			new_path.replace_extension(".blp");
+			if (!hierarchy.file_exists(new_path)) {
+				new_path.replace_extension(".dds");
+			}
 		}
 	}
 


### PR DESCRIPTION
Changed texturesets' handling to support replaceable ids (previously the diffuse got used for all slots)

Made wpm optional, added v15 of the w3i and made the last parts of w3i optional (for beta maps)

Fixed FAFX loading (not storing all the data but the models that have multiple entries only have duplicates of "Node" FAFX, and we don't use FAFX anyway)

Scorched tree is incorrectly cased in the skin file (YTsc instead of Ytsc), so we need to remap that

Fixed filealiases (1.32 changed the slashes used and we can't trust it to stay the same even now)

Fixed triggers more:
Map header and map libraries are just category variants (map libraries are not found in any map, but they are valid in WE)
fixed pre-31 handling of the first category (id 0 category overlaps with map header we insert, so we remap it)

Fixed up unit and doodad code generation