### PR TITLE
1.33 model support

### DIFF
--- a/CMakeSettings.json
+++ b/CMakeSettings.json
@@ -2,7 +2,7 @@
   "configurations": [
     {
       "name": "x64-Debug",
-      "generator": "Ninja",
+      "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Debug",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",
@@ -24,7 +24,7 @@
     },
     {
       "name": "x64-Release",
-      "generator": "Ninja",
+      "generator": "Visual Studio 17 2022 Win64",
       "configurationType": "Release",
       "inheritEnvironments": [ "msvc_x64_x64" ],
       "buildRoot": "${env.USERPROFILE}\\CMakeBuilds\\${workspaceHash}\\build\\${name}",

--- a/src/Base/Hierarchy.ixx
+++ b/src/Base/Hierarchy.ixx
@@ -37,9 +37,9 @@ export class Hierarchy {
 		/*QSettings settings;
 		ptr = settings.value("flavour", "Retail").toString() != "Retail";
 		hd = settings.value("hd", "True").toString() != "False";
-		teen = settings.value("teen", "False").toString() != "False";*/
-		//QSettings war3reg("HKEY_CURRENT_USER\\Software\\Blizzard Entertainment\\Warcraft III", QSettings::NativeFormat);
-		//local_files = war3reg.value("Allow Local Files", 0).toInt() != 0;
+		teen = settings.value("teen", "False").toString() != "False";
+		QSettings war3reg("HKEY_CURRENT_USER\\Software\\Blizzard Entertainment\\Warcraft III", QSettings::NativeFormat);
+		local_files = war3reg.value("Allow Local Files", 0).toInt() != 0;*/
 
 		std::cout << "Loading CASC data from: " << warcraft_directory << "\n";
 		bool open = game_data.open(warcraft_directory / (ptr ? ":w3t" : ":w3"));

--- a/src/File Formats/MDX/MDLWriter.cpp
+++ b/src/File Formats/MDX/MDLWriter.cpp
@@ -200,10 +200,10 @@ namespace mdx {
 		mdl.start_group(fmt::format("Materials {}", materials.size()), [&]() {
 			for (const auto& material : materials) {
 				mdl.start_group("Material", [&]() {
-					mdl.write_line(fmt::format("Shader \"{}\",", material.shader_name));
-
-					for (const auto& layer : material.layers) {
-						mdl.start_group("Layer", [&]() {
+					if (material.layers[0].hd) {
+						mdl.write_line("Shader \"Shader_HD_DefaultUnit\",");
+						const auto& layer = material.layers[0];
+						for (int i = 0; i < 6; i++) {
 							switch (layer.blend_mode) {
 								case 0:
 									mdl.write_line("FilterMode None");
@@ -244,13 +244,67 @@ namespace mdx {
 								mdl.write_line("NoDepthSet");
 							}
 
-							mdl.write_track(layer.KMTF, "TextureID", layer.texture_id);
+							mdl.write_track(layer.textures.at(i).KMTF, "TextureID", layer.textures.at(i).id);
 							mdl.write_track(layer.KMTA, "Alpha", layer.alpha);
 							mdl.write_track(layer.KMTE, "EmissiveGain", layer.emissive_gain);
 							mdl.write_track(layer.KFC3, "FresnelColor", layer.fresnel_color);
 							mdl.write_track(layer.KFCA, "FresnelAlpha", layer.fresnel_opacity);
 							mdl.write_track(layer.KFTC, "FresnelTeamColor", layer.fresnel_team_color);
-						});
+						}
+					}
+					else {
+						mdl.write_line("Shader \"\",");
+
+						for (const auto& layer : material.layers) {
+							mdl.start_group("Layer", [&]() {
+								switch (layer.blend_mode) {
+									case 0:
+										mdl.write_line("FilterMode None");
+										break;
+									case 1:
+										mdl.write_line("FilterMode Transparent");
+										break;
+									case 2:
+										mdl.write_line("FilterMode Blend");
+										break;
+									case 3:
+										mdl.write_line("FilterMode Additive");
+										break;
+									case 4:
+										mdl.write_line("FilterMode AddAlpha");
+										break;
+									case 5:
+										mdl.write_line("FilterMode Modulate");
+										break;
+									case 6:
+										mdl.write_line("FilterMode Modulate2x");
+										break;
+								}
+
+								if (layer.shading_flags & Layer::ShadingFlags::unshaded) {
+									mdl.write_line("Unshaded");
+								}
+
+								if (layer.shading_flags & Layer::ShadingFlags::unfogged) {
+									mdl.write_line("Unfogged");
+								}
+
+								if (layer.shading_flags & Layer::ShadingFlags::no_depth_test) {
+									mdl.write_line("NoDepthTest");
+								}
+
+								if (layer.shading_flags & Layer::ShadingFlags::no_depth_set) {
+									mdl.write_line("NoDepthSet");
+								}
+
+								mdl.write_track(layer.textures.at(0).KMTF, "TextureID", layer.textures.at(0).id);
+								mdl.write_track(layer.KMTA, "Alpha", layer.alpha);
+								mdl.write_track(layer.KMTE, "EmissiveGain", layer.emissive_gain);
+								mdl.write_track(layer.KFC3, "FresnelColor", layer.fresnel_color);
+								mdl.write_track(layer.KFCA, "FresnelAlpha", layer.fresnel_opacity);
+								mdl.write_track(layer.KFTC, "FresnelTeamColor", layer.fresnel_team_color);
+							});
+						}
 					}
 				});
 			}

--- a/src/File Formats/MDX/MDX.ixx
+++ b/src/File Formats/MDX/MDX.ixx
@@ -168,6 +168,11 @@ namespace mdx {
 		}
 	};
 
+	export struct LayerTexture {
+		uint32_t id;
+		TrackHeader<uint32_t> KMTF;
+	};
+
 	export struct Layer {
 		uint32_t blend_mode;
 		uint32_t shading_flags;
@@ -181,7 +186,11 @@ namespace mdx {
 		float fresnel_opacity;
 		float fresnel_team_color;
 
-		TrackHeader<uint32_t> KMTF;
+		bool hd;
+
+		std::unordered_map<uint32_t, LayerTexture> textures;
+
+		TrackHeader<uint32_t> KMTFTemp;
 		TrackHeader<float> KMTA;
 		TrackHeader<float> KMTE;
 		TrackHeader<glm::vec3> KFC3;
@@ -363,7 +372,6 @@ namespace mdx {
 	export struct Material {
 		uint32_t priority_plane;
 		uint32_t flags;
-		std::string shader_name;
 		std::vector<Layer> layers;
 	};
 

--- a/src/File Formats/MDX/MDXWriter.cpp
+++ b/src/File Formats/MDX/MDXWriter.cpp
@@ -115,7 +115,6 @@ namespace mdx {
 
 			writer.write<uint32_t>(material.priority_plane);
 			writer.write<uint32_t>(material.flags);
-			writer.write_c_string_padded(material.shader_name, 80);
 			writer.write_string("LAYS");
 			writer.write<uint32_t>(material.layers.size());
 
@@ -136,7 +135,14 @@ namespace mdx {
 				writer.write<float>(layer.fresnel_opacity);
 				writer.write<float>(layer.fresnel_team_color);
 
-				layer.KMTF.save(TrackTag::KMTF, writer);
+				writer.write<uint32_t>(layer.hd);
+				writer.write<uint32_t>(layer.textures.size());
+				for (auto& pair : layer.textures) {
+					writer.write<uint32_t>(pair.second.id);
+					writer.write<uint32_t>(pair.first);
+					pair.second.KMTF.save(TrackTag::KMTF, writer);
+				}
+
 				layer.KMTA.save(TrackTag::KMTA, writer);
 				layer.KMTE.save(TrackTag::KMTE, writer);
 				layer.KFC3.save(TrackTag::KFC3, writer);
@@ -638,7 +644,7 @@ namespace mdx {
 		writer.write_string("MDLX");
 		writer.write(ChunkTag::VERS);
 		writer.write<uint32_t>(4);
-		writer.write<uint32_t>(1000);
+		writer.write<uint32_t>(1100);
 
 		writer.write(ChunkTag::MODL);
 		writer.write<uint32_t>(372);

--- a/src/HiveWE.cpp
+++ b/src/HiveWE.cpp
@@ -40,13 +40,20 @@ HiveWE::HiveWE(QWidget* parent) : QMainWindow(parent) {
 	setAutoFillBackground(true);
 
 	fs::path directory = find_warcraft_directory();
+	QSettings settings;
+
+	//TODO: these are out of hierarchy while QSettings have ICE in modules
+	hierarchy.ptr = settings.value("flavour", "Retail").toString() != "Retail";
+	hierarchy.hd = settings.value("hd", "True").toString() != "False";
+	hierarchy.teen = settings.value("teen", "False").toString() != "False";
+	QSettings war3reg("HKEY_CURRENT_USER\\Software\\Blizzard Entertainment\\Warcraft III", QSettings::NativeFormat);
+	hierarchy.local_files = war3reg.value("Allow Local Files", 0).toInt() != 0;
 	while (!hierarchy.open_casc(directory)) {
 		directory = QFileDialog::getExistingDirectory(this, "Select Warcraft Directory", "/home", QFileDialog::ShowDirsOnly | QFileDialog::DontResolveSymlinks).toStdWString();
 		if (directory == "") {
 			exit(EXIT_SUCCESS);
 		}
 	}
-	QSettings settings;
 	settings.setValue("warcraftDirectory", QString::fromStdString(directory.string()));
 
 	// Place common.j and blizzard.j in the data folder. Required by JassHelper

--- a/src/Resources/SkinnedMesh.h
+++ b/src/Resources/SkinnedMesh.h
@@ -24,7 +24,6 @@ class SkinnedMesh : public Resource {
 		int material_id = 0;
 		mdx::Extent extent;
 
-		bool hd = true;
 		mdx::GeosetAnimation* geoset_anim; // can be nullptr, often
 	};
 

--- a/src/Resources/SkinnedMesh/SkeletalModelInstance.h
+++ b/src/Resources/SkinnedMesh/SkeletalModelInstance.h
@@ -3,6 +3,7 @@
 #include <chrono>
 #include <vector>
 #include <memory>
+#include <unordered_map>
 
 #define GLM_FORCE_CXX17
 #define GLM_FORCE_RADIANS


### PR DESCRIPTION
v1100 changes:
textures are in a list instead of multiple layers for HD,
KMTF is saved with texture in the list,
layers are defined as either SD or HD, not materials (crystal shader removed),

Changes not from v1100: 
Fix build generators for debug and release,
Add back QSettings capabilities (sadly out of modules for now),
SkinnedMesh was including StaticMesh.h