### PR TITLE
1.33 w3o support

### DIFF
--- a/src/Base/Map.cpp
+++ b/src/Base/Map.cpp
@@ -242,8 +242,16 @@ void Map::load(const fs::path& path) {
 		load_modification_file("war3map.w3d", doodads_slk, doodads_meta_slk, true);
 	}
 
+	if (hierarchy.map_file_exists("war3mapSkin.w3d")) {
+		load_modification_file("war3mapSkin.w3d", doodads_slk, doodads_meta_slk, true);
+	}
+
 	if (hierarchy.map_file_exists("war3map.w3b")) {
 		load_modification_file("war3map.w3b", destructibles_slk, destructibles_meta_slk, false);
+	}
+
+	if (hierarchy.map_file_exists("war3mapSkin.w3b")) {
+		load_modification_file("war3mapSkin.w3b", destructibles_slk, destructibles_meta_slk, false);
 	}
 
 	doodads.load();
@@ -256,8 +264,16 @@ void Map::load(const fs::path& path) {
 		load_modification_file("war3map.w3u", units_slk, units_meta_slk, false);
 	}
 
+	if (hierarchy.map_file_exists("war3mapSkin.w3u")) {
+		load_modification_file("war3mapSkin.w3u", units_slk, units_meta_slk, false);
+	}
+
 	if (hierarchy.map_file_exists("war3map.w3t")) {
 		load_modification_file("war3map.w3t", items_slk, items_meta_slk, false);
+	}
+
+	if (hierarchy.map_file_exists("war3mapSkin.w3t")) {
+		load_modification_file("war3mapSkin.w3t", items_slk, items_meta_slk, false);
 	}
 
 	// Units/Items
@@ -274,14 +290,26 @@ void Map::load(const fs::path& path) {
 		load_modification_file("war3map.w3a", abilities_slk, abilities_meta_slk, true);
 	}
 
+	if (hierarchy.map_file_exists("war3mapSkin.w3a")) {
+		load_modification_file("war3mapSkin.w3a", abilities_slk, abilities_meta_slk, true);
+	}
+
 	// Buffs
 	if (hierarchy.map_file_exists("war3map.w3h")) {
 		load_modification_file("war3map.w3h", buff_slk, buff_meta_slk, false);
 	}
 
+	if (hierarchy.map_file_exists("war3mapSkin.w3h")) {
+		load_modification_file("war3mapSkin.w3h", buff_slk, buff_meta_slk, false);
+	}
+
 	// Upgrades
 	if (hierarchy.map_file_exists("war3map.w3q")) {
 		load_modification_file("war3map.w3q", upgrade_slk, upgrade_meta_slk, true);
+	}
+
+	if (hierarchy.map_file_exists("war3mapSkin.w3q")) {
+		load_modification_file("war3mapSkin.w3q", upgrade_slk, upgrade_meta_slk, true);
 	}
 
 	// Regions
@@ -344,18 +372,25 @@ bool Map::save(const fs::path& path) {
 	pathing_map.save();
 	terrain.save();
 
-	save_modification_file("war3map.w3d", doodads_slk, doodads_meta_slk, true);
-	save_modification_file("war3map.w3b", destructibles_slk, destructibles_meta_slk, false);
+	save_modification_file("war3map.w3d", doodads_slk, doodads_meta_slk, true, false);
+	save_modification_file("war3mapSkin.w3d", doodads_slk, doodads_meta_slk, true, true);
+	save_modification_file("war3map.w3b", destructibles_slk, destructibles_meta_slk, false, false);
+	save_modification_file("war3mapSkin.w3b", destructibles_slk, destructibles_meta_slk, false, true);
 	doodads.save();
 
-	save_modification_file("war3map.w3u", units_slk, units_meta_slk, false);
-	save_modification_file("war3map.w3t", items_slk, items_meta_slk, false);
+	save_modification_file("war3map.w3u", units_slk, units_meta_slk, false, false);
+	save_modification_file("war3mapSkin.w3u", units_slk, units_meta_slk, false, true);
+	save_modification_file("war3map.w3t", items_slk, items_meta_slk, false, false);
+	save_modification_file("war3mapSkin.w3t", items_slk, items_meta_slk, false, true);
 	units.save();
 
-	save_modification_file("war3map.w3a", abilities_slk, abilities_meta_slk, true);
+	save_modification_file("war3map.w3a", abilities_slk, abilities_meta_slk, true, false);
+	save_modification_file("war3mapSkin.w3a", abilities_slk, abilities_meta_slk, true, true);
 
-	save_modification_file("war3map.w3h", buff_slk, buff_meta_slk, false);
-	save_modification_file("war3map.w3q", upgrade_slk, upgrade_meta_slk, true);
+	save_modification_file("war3map.w3h", buff_slk, buff_meta_slk, false, false);
+	save_modification_file("war3mapSkin.w3h", buff_slk, buff_meta_slk, false, true);
+	save_modification_file("war3map.w3q", upgrade_slk, upgrade_meta_slk, true, false);
+	save_modification_file("war3mapSkin.w3q", upgrade_slk, upgrade_meta_slk, true, true);
 
 	info.save(terrain.tileset);
 	trigger_strings.save();

--- a/src/Utilities.h
+++ b/src/Utilities.h
@@ -12,7 +12,7 @@ import BinaryReader;
 import BinaryWriter;
 #include "SLK.h"
 
-constexpr int mod_table_write_version = 2;
+constexpr int mod_table_write_version = 3;
 namespace fs = std::filesystem;
 
 class Shapes {
@@ -54,9 +54,9 @@ std::string read_text_file(const fs::path& path);
 fs::path find_warcraft_directory();
 
 void load_modification_file(const std::string file_name, slk::SLK& base_data, slk::SLK& meta_slk, bool optional_ints);
-void load_modification_table(BinaryReader& reader, slk::SLK& slk, slk::SLK& meta_slk, bool modification, bool optional_ints);
-void save_modification_file(const std::string file_name, slk::SLK& slk, slk::SLK& meta_slk, bool optional_ints);
-void save_modification_table(BinaryWriter& writer, slk::SLK& slk, slk::SLK& meta_slk, bool custom, bool optional_ints);
+void load_modification_table(BinaryReader& reader, uint32_t version, slk::SLK& slk, slk::SLK& meta_slk, bool modification, bool optional_ints);
+void save_modification_file(const std::string file_name, slk::SLK& slk, slk::SLK& meta_slk, bool optional_ints, bool skin);
+void save_modification_table(BinaryWriter& writer, slk::SLK& slk, slk::SLK& meta_slk, bool custom, bool optional_ints, bool skin);
 
 /// Convert a Tground texture into an QIcon with two states
 QIcon ground_texture_to_icon(uint8_t* data, int width, int height);

--- a/src/Utilities/OpenGLUtilities.h
+++ b/src/Utilities/OpenGLUtilities.h
@@ -11,8 +11,6 @@ import BinaryWriter;
 
 namespace fs = std::filesystem;
 
-constexpr int mod_table_write_version = 2;
-
 class Shapes {
   public:
 	void init();

--- a/src/Utilities/Utilities.ixx
+++ b/src/Utilities/Utilities.ixx
@@ -14,8 +14,6 @@ export module Utilities;
 
 namespace fs = std::filesystem;
 
-constexpr int mod_table_write_version = 2;
-
 // String functions
 export std::string string_replaced(const std::string& source, const std::string& from, const std::string& to) {
 	std::string new_string;


### PR DESCRIPTION
Version updated to 3, two new fields in every unit's definition, a new set of files that store "netsafe" data, and these files aren't used for the map's hash.
This means an object editor can be made that supports editing SD and HD data separately, by creating a second war3mapSkin.w3* file set in _hd.w3mod
Saving currently stores all data in the main file set as this is also valid and took less effort to implement (I'm not good at the SLK and object data parts of this 😅)