### PR TITLE
Correct unit loading logic for 1.29.X

### DIFF
--- a/src/base/units.cpp
+++ b/src/base/units.cpp
@@ -75,7 +75,7 @@ void Units::load() {
 		i.flags = reader.read<uint8_t>();
 
 		i.player = reader.read<uint32_t>();
-		if (i.player > 11 && map->info.editor_version < 6061) {
+		if (i.player > 11 && map->info.editor_version < 6060) {
 			i.player += 12;
 		}
 


### PR DESCRIPTION
1.29.X patches have editor version 6060, and 1.29 is the patch that increased the player limit to 24, pushing neutrals away from 12-15 to 24-27