### PR TITLE
Terrain brush fixups

### DIFF
--- a/data/shaders/cliff.frag
+++ b/data/shaders/cliff.frag
@@ -43,7 +43,7 @@ void main() {
 			extra_offset.y = 0.25f;
 		}
 
-		vec2 brush_uv = ((brush_position - world_position) * 4.f) / vec2(brush_texture_size) + 0.5;
+		vec2 brush_uv = ((world_position - brush_position) * 4.f) / vec2(brush_texture_size) + 0.5;
 
 		vec4 brush_color = texture(brush, brush_uv);
 

--- a/data/shaders/terrain.frag
+++ b/data/shaders/terrain.frag
@@ -56,7 +56,7 @@ void main() {
 	if (render_brush) {
 		ivec2 brush_texture_size = textureSize(brush, 0);
 
-		vec2 brush_uv = ((brush_position - world_position) * 4.f) / vec2(brush_texture_size) + 0.5;
+		vec2 brush_uv = ((world_position - brush_position) * 4.f) / vec2(brush_texture_size) + 0.5;
 
 		vec4 brush_color = texture(brush, brush_uv);
 

--- a/src/brush/terrain_brush.cpp
+++ b/src/brush/terrain_brush.cpp
@@ -89,8 +89,8 @@ void TerrainBrush::check_nearby(const int begx, const int begy, const std::vecto
 	const int height = map->terrain.height;
 	const int corner_width = width + 1;
 	const int corner_height = height + 1;
-	std::vector<uint8_t> visited(static_cast<size_t>(corner_width * corner_height), 0);
-	auto visit_index = [corner_width](int x, int y) {
+	hive::unordered_map<size_t, bool> visited;
+	auto linear_index = [corner_width](int x, int y) {
 		return static_cast<size_t>(y * corner_width + x);
 	};
 
@@ -100,11 +100,11 @@ void TerrainBrush::check_nearby(const int begx, const int begy, const std::vecto
 		if (seed.x < 0 || seed.x >= corner_width || seed.y < 0 || seed.y >= corner_height) {
 			continue;
 		}
-		const size_t index = visit_index(seed.x, seed.y);
-		if (visited[index] != 0) {
+		const size_t index = linear_index(seed.x, seed.y);
+		if (visited[index]) {
 			continue;
 		}
-		visited[index] = 1;
+		visited[index] = true;
 		stack.emplace_back(seed);
 	}
 
@@ -116,7 +116,7 @@ void TerrainBrush::check_nearby(const int begx, const int begy, const std::vecto
 
 		for (int k = bounds.x(); k <= bounds.right(); k++) {
 			for (int l = bounds.y(); l <= bounds.bottom(); l++) {
-				if (visited[visit_index(k, l)] != 0) {
+				if (visited[linear_index(k, l)]) {
 					continue;
 				}
 
@@ -130,7 +130,7 @@ void TerrainBrush::check_nearby(const int begx, const int begy, const std::vecto
 					area.setRight(std::max(area.right(), k));
 					area.setBottom(std::max(area.bottom(), l));
 
-					visited[visit_index(k, l)] = 1;
+					visited[linear_index(k, l)] = true;
 					stack.emplace_back(k, l);
 				}
 			}

--- a/src/brush/terrain_brush.cpp
+++ b/src/brush/terrain_brush.cpp
@@ -217,8 +217,8 @@ void TerrainBrush::apply(double frame_delta) {
 				}
 
 				bool cliff_near = false;
-				for (int k = -1; k < 1; k++) {
-					for (int l = -1; l < 1; l++) {
+				for (int k = -1; k <= 1; k++) {
+					for (int l = -1; l <= 1; l++) {
 						if (i + k >= 0 && i + k <= width && j + l >= 0 && j + l <= height) {
 							cliff_near = cliff_near || corners[i + k][j + l].cliff;
 						}

--- a/src/brush/terrain_brush.h
+++ b/src/brush/terrain_brush.h
@@ -57,7 +57,7 @@ public:
 	void mouse_press_event(QMouseEvent* event, double frame_delta) override;
 	void mouse_move_event(QMouseEvent* event, double frame_delta) override;
 
-	void check_nearby(int begx, int begy, int i, int j, QRect& area) const;
+	void check_nearby(int begx, int begy, const std::vector<glm::ivec2>& seeds, QRect& area) const;
 
 	void apply_begin() override;
 	void apply(double frame_delta) override;


### PR DESCRIPTION
* Use DP to optimize the apply call's updated area
* Fix the 3x3 kernel for cliff_near
* Unflip the brush's display