### PR TITLE
Map Size and Camera Bounds

### DIFF
--- a/src/base/doodads.ixx
+++ b/src/base/doodads.ixx
@@ -220,7 +220,7 @@ export class Doodads {
 		doodads.erase(iterator);
 	}
 
-	void remove_sepcial_doodad(SpecialDoodad* doodad) {
+	void remove_special_doodad(SpecialDoodad* doodad) {
 		const auto iterator = special_doodads.begin() + std::distance(special_doodads.data(), doodad);
 		special_doodads.erase(iterator);
 	}

--- a/src/base/doodads.ixx
+++ b/src/base/doodads.ixx
@@ -220,8 +220,19 @@ export class Doodads {
 		doodads.erase(iterator);
 	}
 
+	void remove_sepcial_doodad(SpecialDoodad* doodad) {
+		const auto iterator = special_doodads.begin() + std::distance(special_doodads.data(), doodad);
+		special_doodads.erase(iterator);
+	}
+
 	void remove_doodads(const std::unordered_set<Doodad*>& list) {
 		std::erase_if(doodads, [&](Doodad& doodad) {
+			return list.contains(&doodad);
+		});
+	}
+
+	void remove_special_doodads(const std::unordered_set<SpecialDoodad*>& list) {
+		std::erase_if(special_doodads, [&](SpecialDoodad& doodad) {
 			return list.contains(&doodad);
 		});
 	}

--- a/src/base/game_cameras.ixx
+++ b/src/base/game_cameras.ixx
@@ -26,7 +26,7 @@ export class GameCameras {
   public:
 	std::vector<GameCamera> cameras;
 
-	void load(int game_version_major, int game_version_minor) {
+	void load(int game_version_major, int game_version_minor, float terrain_offset_x, float terrain_offset_y) {
 		BinaryReader reader = hierarchy.map_file_read("war3map.w3c").value();
 
 		int version = reader.read<u32>();
@@ -36,9 +36,12 @@ export class GameCameras {
 
 		cameras.resize(reader.read<u32>());
 		for (auto& i : cameras) {
-			i.target_x = reader.read<float>();
-			i.target_y = reader.read<float>();
-			i.z_offset = reader.read<float>();
+			// change coordinate system to [0, terrain_width] x [0, terrain_height]
+			// as used by other objects in HiveWE
+			i.target_x = (reader.read<float>() - terrain_offset_x) / 128.f;
+			i.target_y = (reader.read<float>() - terrain_offset_y) / 128.f;
+			i.z_offset = reader.read<float>() / 128.f;
+
 			i.rotation = reader.read<float>();
 			i.angle_of_attack = reader.read<float>();
 			i.distance = reader.read<float>();
@@ -56,6 +59,16 @@ export class GameCameras {
 		}
 	}
 
-	void save() {
+	void save() {}
+
+	void remove_camera(GameCamera* camera) {
+		const auto iterator = cameras.begin() + std::distance(cameras.data(), camera);
+		cameras.erase(iterator);
+	}
+
+	void remove_cameras(const std::unordered_set<GameCamera*>& list) {
+		std::erase_if(cameras, [&](GameCamera& camera) {
+			return list.contains(&camera);
+		});
 	}
 };

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -756,16 +756,15 @@ export class Map: public QObject {
 	/// Handles the terrain flags, camera bounds and map info
 	/// Also updates the pathing map and deletes units/items which are now out of bounds
 	void set_playable_area(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
-		int old_left = info.camera_complements[0];
-		int old_right = info.camera_complements[1];
-		int old_bottom = info.camera_complements[2];
-		int old_top = info.camera_complements[3];
-
 		// apply the shadowed camera boundaries on the edges
 		terrain.set_unplayable_boundaries(unplayable_left, unplayable_right, unplayable_top, unplayable_bottom);
 
 		// reset the pathing map - old unplayable segments should
 		// no longer be unwalkable/unflyable/unbuildable
+		int old_left = info.camera_complements[0];
+		int old_right = info.camera_complements[1];
+		int old_bottom = info.camera_complements[2];
+		int old_top = info.camera_complements[3];
 		reset_map_edge_pathing(
 			old_left,
 			old_right,
@@ -777,29 +776,8 @@ export class Map: public QObject {
 			unplayable_bottom
 		);
 
-		// update unplayable area in map info
-		info.camera_complements[0] = unplayable_left;
-		info.camera_complements[1] = unplayable_right;
-		info.camera_complements[2] = unplayable_bottom;
-		info.camera_complements[3] = unplayable_top;
-
-		// update playable map area
-		info.playable_width = terrain.width - 1 - info.camera_complements[0] - info.camera_complements[1];
-		info.playable_height = terrain.height - 1 - info.camera_complements[2] - info.camera_complements[3];
-
-		// compute camera bounds based on complements and terrain offset
-		// these bounds are used in the generated JASS script
-		info.camera_left_bottom.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
-		info.camera_left_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
-
-		info.camera_right_top.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
-		info.camera_right_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
-
-		info.camera_left_top.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
-		info.camera_left_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
-
-		info.camera_right_bottom.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
-		info.camera_right_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
+		// update map info
+		update_map_bounds_info(unplayable_left, unplayable_right, unplayable_top, unplayable_bottom);
 	}
 
 	std::string get_unique_id(bool first_uppercase) {
@@ -924,6 +902,32 @@ export class Map: public QObject {
 		}
 
 		pathing_map.upload_static_pathing();
+	}
+
+	void update_map_bounds_info(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
+		// update unplayable area in map info
+		info.camera_complements[0] = unplayable_left;
+		info.camera_complements[1] = unplayable_right;
+		info.camera_complements[2] = unplayable_bottom;
+		info.camera_complements[3] = unplayable_top;
+
+		// update playable map area
+		info.playable_width = terrain.width - 1 - info.camera_complements[0] - info.camera_complements[1];
+		info.playable_height = terrain.height - 1 - info.camera_complements[2] - info.camera_complements[3];
+
+		// compute camera bounds based on complements and terrain offset
+		// these bounds are used in the generated JASS script
+		info.camera_left_bottom.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
+		info.camera_left_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
+
+		info.camera_right_top.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
+		info.camera_right_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
+
+		info.camera_left_top.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
+		info.camera_left_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
+
+		info.camera_right_bottom.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
+		info.camera_right_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
 	}
 };
 

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -724,11 +724,6 @@ export class Map: public QObject {
 		// physics.draw->render();
 	}
 
-	void resize(size_t width, size_t height) {
-		terrain.resize(width, height);
-		pathing_map.resize(width * 4, height * 4);
-	}
-
 	/// Resizes the entire map by expanding/shirnking it from all sides
 	/// Handles terrain, pathing map, shadow map and preplaced objects
 	/// Also, as per vanilla WE behaviour, clears the entire world undo stack
@@ -840,8 +835,10 @@ export class Map: public QObject {
 		const int height = terrain.height - 1;
 
 		// helper to update positions and collect out-of-bounds objects for removal
-		auto update_and_collect_unit = [&](auto& container) {
-			std::unordered_set<Unit*> to_delete;
+		auto update_and_collect = [&](auto& container, auto&& update_func) {
+			using ObjectType = std::decay_t<decltype(*container.begin())>;
+			using PointerType = std::remove_reference_t<ObjectType>*;
+			std::unordered_set<PointerType> to_delete;
 
 			for (auto& obj : container) {
 				// update the object position relative to the change in bottom-left corner
@@ -854,28 +851,7 @@ export class Map: public QObject {
 					++num_deleted;
 				} else {
 					// update rendered object position
-					obj.update();
-				}
-			}
-
-			return to_delete;
-		};
-
-		auto update_and_collect_doodad = [&](auto& container) {
-			std::unordered_set<Doodad*> to_delete;
-
-			for (auto& obj : container) {
-				// update the object position relative to the change in bottom-left corner
-				obj.position.x += delta_left;
-				obj.position.y += delta_bottom;
-
-				// check if the object is outside map bounds
-				if (obj.position.x < 0 || obj.position.y < 0 || obj.position.x > width || obj.position.y > height) {
-					to_delete.insert(&obj);
-					++num_deleted;
-				} else {
-					// update rendered object position
-					obj.update(terrain);
+					update_func(obj);
 				}
 			}
 
@@ -883,12 +859,19 @@ export class Map: public QObject {
 		};
 
 		// fix/remove all objects
-		units.remove_units(update_and_collect_unit(units.units));
-		units.remove_items(update_and_collect_unit(units.items));
-		doodads.remove_doodads(update_and_collect_doodad(doodads.doodads));
+		units.remove_units(update_and_collect(units.units, [](auto& obj) {
+			obj.update();
+		}));
 
-		// TODO: once special doodads are implemented, handle them as well
-		//doodads.remove_special_doodads(update_and_collect_doodad(doodads.special_doodads));
+		units.remove_items(update_and_collect(units.items, [](auto& obj) {
+			obj.update();
+		}));
+
+		doodads.remove_doodads(update_and_collect(doodads.doodads, [&](auto& obj) {
+			obj.update(terrain);
+		}));
+
+		doodads.remove_special_doodads(update_and_collect(doodads.special_doodads, [](auto& obj) { /* TODO: obj.update(terrain) */ }));
 
 		// TODO: once cameras and regions are implemented, handle them too
 

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -858,7 +858,7 @@ export class Map: public QObject {
 			obj.update(terrain);
 		}));
 
-		doodads.remove_special_doodads(update_and_collect(doodads.special_doodads, [](auto& obj) {
+		doodads.remove_special_doodads(update_and_collect(doodads.special_doodads, [&](auto& obj) {
 			obj.update(terrain);
 		}));
 
@@ -871,7 +871,7 @@ export class Map: public QObject {
 
 			// check if the camera is outside map bounds
 			if (camera.target_x < 0 || camera.target_y < 0 || camera.target_x > width || camera.target_y > height) {
-				to_delete.insert(&camera);
+				cameras_to_delete.insert(&camera);
 				++num_deleted;
 			} else {
 				// todo: uncomment once implemented
@@ -884,10 +884,10 @@ export class Map: public QObject {
 		std::unordered_set<Region*> regions_to_delete;
 		for (Region& region : regions.regions) {
 			// update the region position
-			region.left = max(region.left + delta_left, 0.f);
-			region.right = min(region.right + delta_left, float(width));
-			region.bottom = max(region.bottom + delta_bottom, 0.f);
-			region.top = min(region.top + delta_bottom, float(height));
+			region.left = std::max(region.left + delta_left, 0.f);
+			region.right = std::min(region.right + delta_left, float(width));
+			region.bottom = std::max(region.bottom + delta_bottom, 0.f);
+			region.top = std::min(region.top + delta_bottom, float(height));
 
 			// check if the region was destroyed by the resize operation
 			if (region.right <= region.left || region.top <= region.bottom) {

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -412,12 +412,12 @@ export class Map: public QObject {
 
 		// Regions
 		if (hierarchy.map_file_exists("war3map.w3r")) {
-			regions.load();
+			regions.load(terrain.offset.x, terrain.offset.y);
 		}
 
 		// Cameras
 		if (hierarchy.map_file_exists("war3map.w3c")) {
-			cameras.load(info.game_version_major, info.game_version_minor);
+			cameras.load(info.game_version_major, info.game_version_minor, terrain.offset.x, terrain.offset.y);
 		}
 
 		// Sounds
@@ -858,9 +858,47 @@ export class Map: public QObject {
 			obj.update(terrain);
 		}));
 
-		doodads.remove_special_doodads(update_and_collect(doodads.special_doodads, [](auto& obj) { /* TODO: obj.update(terrain) */ }));
+		doodads.remove_special_doodads(update_and_collect(doodads.special_doodads, [](auto& obj) {
+			obj.update(terrain);
+		}));
 
-		// TODO: once cameras and regions are implemented, handle them too
+		// fix and remove cameras
+		std::unordered_set<GameCamera*> cameras_to_delete;
+		for (GameCamera& camera : cameras.cameras) {
+			// update the camera position
+			camera.target_x += delta_left;
+			camera.target_y += delta_bottom;
+
+			// check if the camera is outside map bounds
+			if (camera.target_x < 0 || camera.target_y < 0 || camera.target_x > width || camera.target_y > height) {
+				to_delete.insert(&camera);
+				++num_deleted;
+			} else {
+				// todo: uncomment once implemented
+				// camera.update()
+			}
+		}
+		cameras.remove_cameras(cameras_to_delete);
+
+		// fix and remove regions
+		std::unordered_set<Region*> regions_to_delete;
+		for (Region& region : regions.regions) {
+			// update the region position
+			region.left = max(region.left + delta_left, 0.f);
+			region.right = min(region.right + delta_left, float(width));
+			region.bottom = max(region.bottom + delta_bottom, 0.f);
+			region.top = min(region.top + delta_bottom, float(height));
+
+			// check if the region was destroyed by the resize operation
+			if (region.right <= region.left || region.top <= region.bottom) {
+				regions_to_delete.insert(&region);
+				++num_deleted;
+			} else {
+				// todo: uncomment once implemented
+				// region.update()
+			}
+		}
+		regions.remove_regions(regions_to_delete);
 
 		return num_deleted;
 	}

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -777,7 +777,16 @@ export class Map: public QObject {
 		);
 
 		// update map info
-		update_map_bounds_info(unplayable_left, unplayable_right, unplayable_top, unplayable_bottom);
+		info.update_map_bounds_info(
+			unplayable_left,
+			unplayable_right,
+			unplayable_top,
+			unplayable_bottom,
+			terrain.width,
+			terrain.height,
+			terrain.offset.x,
+			terrain.offset.y
+		);
 	}
 
 	std::string get_unique_id(bool first_uppercase) {
@@ -902,32 +911,6 @@ export class Map: public QObject {
 		}
 
 		pathing_map.upload_static_pathing();
-	}
-
-	void update_map_bounds_info(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
-		// update unplayable area in map info
-		info.camera_complements[0] = unplayable_left;
-		info.camera_complements[1] = unplayable_right;
-		info.camera_complements[2] = unplayable_bottom;
-		info.camera_complements[3] = unplayable_top;
-
-		// update playable map area
-		info.playable_width = terrain.width - 1 - info.camera_complements[0] - info.camera_complements[1];
-		info.playable_height = terrain.height - 1 - info.camera_complements[2] - info.camera_complements[3];
-
-		// compute camera bounds based on complements and terrain offset
-		// these bounds are used in the generated JASS script
-		info.camera_left_bottom.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
-		info.camera_left_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
-
-		info.camera_right_top.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
-		info.camera_right_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
-
-		info.camera_left_top.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
-		info.camera_left_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
-
-		info.camera_right_bottom.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
-		info.camera_right_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
 	}
 };
 

--- a/src/base/map.ixx
+++ b/src/base/map.ixx
@@ -18,6 +18,7 @@ import Regions;
 import WorldUndoManager;
 import TriggerStrings;
 import PathingMap;
+import ShadowMap;
 import Physics;
 import Hierarchy;
 import Camera;
@@ -59,8 +60,7 @@ export class Map: public QObject {
 	GameCameras cameras;
 	Sounds sounds;
 	GameplayConstants gameplay_constants;
-	// ShadowMap shadow_map;
-
+	ShadowMap shadow_map;
 	WorldUndoManager world_undo;
 	Brush* brush = nullptr;
 	Physics physics;
@@ -428,6 +428,16 @@ export class Map: public QObject {
 		std::println("Misc loading:\t {:>5}ms", timer.elapsed_ms());
 		timer.reset();
 
+		// Shadow map
+		if (hierarchy.map_file_exists("war3map.shd")) {
+			shadow_map.load(terrain.width - 1, terrain.height - 1);
+		} else {
+			shadow_map.resize((terrain.width - 1) * 4, (terrain.height - 1) * 4);
+		}
+
+		std::println("Shadows loading: {:>5}ms", timer.elapsed_ms());
+		timer.reset();
+
 		// Center camera
 		camera.position = glm::vec3(terrain.width / 2, terrain.height / 2, 0);
 		camera.position.z = terrain.interpolated_height(camera.position.x, camera.position.y, true);
@@ -540,6 +550,7 @@ export class Map: public QObject {
 
 		pathing_map.save();
 		terrain.save();
+		shadow_map.save();
 
 		save_modification_file("war3map.w3d", doodads_slk, doodads_meta_slk, true, false);
 		save_modification_file("war3mapSkin.w3d", doodads_slk, doodads_meta_slk, true, true);
@@ -718,11 +729,89 @@ export class Map: public QObject {
 		pathing_map.resize(width * 4, height * 4);
 	}
 
+	/// Resizes the entire map by expanding/shirnking it from all sides
+	/// Handles terrain, pathing map, shadow map and preplaced objects
+	/// Also, as per vanilla WE behaviour, clears the entire world undo stack
+	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
+		terrain.resize(delta_left, delta_right, delta_top, delta_bottom, physics);
+
+		// update the pathing and shadow maps to the new size
+		pathing_map.resize(delta_left * 4, delta_right * 4, delta_top * 4, delta_bottom * 4);
+		shadow_map.resize(delta_left * 4, delta_right * 4, delta_top * 4, delta_bottom * 4);
+
+		// update object positions
+		update_object_positions(delta_left, delta_right, delta_top, delta_bottom);
+
+		// vanilla WE behaviour: clear unit/doodad/terrain undo
+		world_undo.clear_all_undo();
+
+		// since this function does not change playable area, we have to update the map info accordingly
+		info.camera_complements[0] += delta_left;
+		info.camera_complements[1] += delta_right;
+		info.camera_complements[2] += delta_bottom;
+		info.camera_complements[3] += delta_top;
+
+		// finally, move the camera
+		camera.position.x += delta_left / 2;
+		camera.position.y += delta_bottom / 2;
+		camera.update(0.0);
+	}
+
+	/// Sets the playable area (shadowed map bounds)
+	/// Handles the terrain flags, camera bounds and map info
+	/// Also updates the pathing map and deletes units/items which are now out of bounds
+	void set_playable_area(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
+		int old_left = info.camera_complements[0];
+		int old_right = info.camera_complements[1];
+		int old_bottom = info.camera_complements[2];
+		int old_top = info.camera_complements[3];
+
+		// apply the shadowed camera boundaries on the edges
+		terrain.set_unplayable_boundaries(unplayable_left, unplayable_right, unplayable_top, unplayable_bottom);
+
+		// reset the pathing map - old unplayable segments should
+		// no longer be unwalkable/unflyable/unbuildable
+		reset_map_edge_pathing(
+			old_left,
+			old_right,
+			old_top,
+			old_bottom,
+			unplayable_left,
+			unplayable_right,
+			unplayable_top,
+			unplayable_bottom
+		);
+
+		// update unplayable area in map info
+		info.camera_complements[0] = unplayable_left;
+		info.camera_complements[1] = unplayable_right;
+		info.camera_complements[2] = unplayable_bottom;
+		info.camera_complements[3] = unplayable_top;
+
+		// update playable map area
+		info.playable_width = terrain.width - 1 - info.camera_complements[0] - info.camera_complements[1];
+		info.playable_height = terrain.height - 1 - info.camera_complements[2] - info.camera_complements[3];
+
+		// compute camera bounds based on complements and terrain offset
+		// these bounds are used in the generated JASS script
+		info.camera_left_bottom.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
+		info.camera_left_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
+
+		info.camera_right_top.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
+		info.camera_right_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
+
+		info.camera_left_top.x = (info.camera_complements[0] + 4) * 128.f + terrain.offset.x;
+		info.camera_left_top.y = (terrain.height - 1 - info.camera_complements[3] - 2) * 128.f + terrain.offset.y;
+
+		info.camera_right_bottom.x = (terrain.width - 1 - info.camera_complements[1] - 4) * 128.f + terrain.offset.x;
+		info.camera_right_bottom.y = (info.camera_complements[2] + 2) * 128.f + terrain.offset.y;
+	}
+
 	std::string get_unique_id(bool first_uppercase) {
 		std::random_device rd;
 		std::mt19937 mt(rd());
 		std::uniform_int_distribution<int> dist(0, 25);
-		again:
+	again:
 
 		std::string id =
 			""s + char((first_uppercase ? 'A' : 'a') + dist(mt)) + char('a' + dist(mt)) + char('a' + dist(mt)) + char('a' + dist(mt));
@@ -735,6 +824,123 @@ export class Map: public QObject {
 		}
 
 		return id;
+	}
+
+  private:
+	/// called when resizing the map
+	/// in HiveWE objeccts positions are saved relative to the bottom-left corner of the terrain
+	/// resizing the map may nudge all preplaced objeccts (units, doodads...)
+	/// calling this function will restore original positions after the resize
+	/// also, if will delete objects which are now out of bounds
+	int update_object_positions(int delta_left, int delta_right, int delta_top, int delta_bottom) {
+		size_t num_deleted = 0;
+
+		// terrain is already resized here
+		const int width = terrain.width - 1;
+		const int height = terrain.height - 1;
+
+		// helper to update positions and collect out-of-bounds objects for removal
+		auto update_and_collect_unit = [&](auto& container) {
+			std::unordered_set<Unit*> to_delete;
+
+			for (auto& obj : container) {
+				// update the object position relative to the change in bottom-left corner
+				obj.position.x += delta_left;
+				obj.position.y += delta_bottom;
+
+				// check if the object is outside map bounds
+				if (obj.position.x < 0 || obj.position.y < 0 || obj.position.x > width || obj.position.y > height) {
+					to_delete.insert(&obj);
+					++num_deleted;
+				} else {
+					// update rendered object position
+					obj.update();
+				}
+			}
+
+			return to_delete;
+		};
+
+		auto update_and_collect_doodad = [&](auto& container) {
+			std::unordered_set<Doodad*> to_delete;
+
+			for (auto& obj : container) {
+				// update the object position relative to the change in bottom-left corner
+				obj.position.x += delta_left;
+				obj.position.y += delta_bottom;
+
+				// check if the object is outside map bounds
+				if (obj.position.x < 0 || obj.position.y < 0 || obj.position.x > width || obj.position.y > height) {
+					to_delete.insert(&obj);
+					++num_deleted;
+				} else {
+					// update rendered object position
+					obj.update(terrain);
+				}
+			}
+
+			return to_delete;
+		};
+
+		// fix/remove all objects
+		units.remove_units(update_and_collect_unit(units.units));
+		units.remove_items(update_and_collect_unit(units.items));
+		doodads.remove_doodads(update_and_collect_doodad(doodads.doodads));
+
+		// TODO: once special doodads are implemented, handle them as well
+		//doodads.remove_special_doodads(update_and_collect_doodad(doodads.special_doodads));
+
+		// TODO: once cameras and regions are implemented, handle them too
+
+		return num_deleted;
+	}
+
+	/// Recomputes the terrain pathing on the edges of the map
+	void reset_map_edge_pathing(
+		int old_left,
+		int old_right,
+		int old_top,
+		int old_bottom,
+		int new_left,
+		int new_right,
+		int new_top,
+		int new_bottom
+	) {
+		int width = (terrain.width - 1) * 4;
+		int height = (terrain.height - 1) * 4;
+
+		// old unplayable segments (on the pathing map)
+		int old_left_p = old_left * 4;
+		int old_right_p = old_right * 4;
+		int old_bottom_p = old_bottom * 4;
+		int old_top_p = old_top * 4;
+
+		// new unplayable segments (on the pathing map)
+		int new_left_p = new_left * 4;
+		int new_right_p = new_right * 4;
+		int new_bottom_p = new_bottom * 4;
+		int new_top_p = new_top * 4;
+
+		constexpr uint8_t edge_pathing = PathingMap::unwalkable | PathingMap::unflyable | PathingMap::unbuildable;
+
+		for (size_t i = 0; i < width; ++i) {
+			for (size_t j = 0; j < height; ++j) {
+				// check if outside new boundaries (in unplayable area)
+				bool outside_new = (i < new_left_p || i >= width - new_right_p || j < new_bottom_p || j >= height - new_top_p);
+
+				// check if outside old boundaries (in old unplayable area)
+				bool outside_old = (i < old_left_p || i >= width - old_right_p || j < old_bottom_p || j >= height - old_top_p);
+
+				// update the pathing map
+				if (outside_new) {
+					pathing_map.pathing_cells_static[j * width + i] = edge_pathing;
+				} else if (outside_old) {
+					pathing_map.pathing_cells_static[j * width + i] = terrain.get_terrain_pathing(i, j);
+				}
+			}
+		}
+
+		pathing_map.upload_static_pathing();
 	}
 };
 

--- a/src/base/map_info.ixx
+++ b/src/base/map_info.ixx
@@ -521,4 +521,39 @@ export class MapInfo {
 
 		hierarchy.map_file_write("war3map.w3i", writer.buffer);
 	}
+
+	void update_map_bounds_info(
+		int unplayable_left,
+		int unplayable_right,
+		int unplayable_top,
+		int unplayable_bottom,
+		int terrain_width,
+		int terrain_height,
+		float terrain_offset_x,
+		float terrain_offset_y
+	) {
+		// update unplayable area in map info
+		camera_complements[0] = unplayable_left;
+		camera_complements[1] = unplayable_right;
+		camera_complements[2] = unplayable_bottom;
+		camera_complements[3] = unplayable_top;
+
+		// update playable map area
+		playable_width = terrain_width - 1 - camera_complements[0] - camera_complements[1];
+		playable_height = terrain_height - 1 - camera_complements[2] - camera_complements[3];
+
+		// compute camera bounds based on complements and terrain offset
+		// these bounds are used in the generated JASS script
+		camera_left_bottom.x = (camera_complements[0] + 4) * 128.f + terrain_offset_x;
+		camera_left_bottom.y = (camera_complements[2] + 2) * 128.f + terrain_offset_y;
+
+		camera_right_top.x = (terrain_width - 1 - camera_complements[1] - 4) * 128.f + terrain_offset_x;
+		camera_right_top.y = (terrain_height - 1 - camera_complements[3] - 2) * 128.f + terrain_offset_y;
+
+		camera_left_top.x = (camera_complements[0] + 4) * 128.f + terrain_offset_x;
+		camera_left_top.y = (terrain_height - 1 - camera_complements[3] - 2) * 128.f + terrain_offset_y;
+
+		camera_right_bottom.x = (terrain_width - 1 - camera_complements[1] - 4) * 128.f + terrain_offset_x;
+		camera_right_bottom.y = (camera_complements[2] + 2) * 128.f + terrain_offset_y;
+	}
 };

--- a/src/base/map_info.ixx
+++ b/src/base/map_info.ixx
@@ -409,29 +409,12 @@ export class MapInfo {
 		writer.write(playable_width);
 		writer.write(playable_height);
 
-		const int flags = hide_minimap_preview * 0x0001 
-						| modif_ally_priorities * 0x0002
-						| melee_map * 0x0004
-						| unknown * 0x0008
-						| masked_area_partially_visible * 0x0010
-						| fixed_player_settings * 0x0020
-						| custom_forces * 0x0040
-						| custom_techtree * 0x0080
-						| custom_abilities * 0x0100
-						| custom_upgrades * 0x0200
-						| unknown2 * 0x0400
-						| cliff_shore_waves * 0x0800
-						| rolling_shore_waves * 0x1000
-						| unknown3 * 0x2000
-						| unknown4 * 0x4000
-						| item_classification * 0x8000
-						| water_tinting * 0x10000
-						| accurate_probability_for_calculations * 0x20000
-						| custom_ability_skins * 0x40000
-						| disable_deny_icon * 0x80000	
-						| force_default_zoom * 0x100000
-						| force_max_zoom * 0x200000
-						| force_min_zoom * 0x400000;
+		const int flags = hide_minimap_preview * 0x0001 | modif_ally_priorities * 0x0002 | melee_map * 0x0004 | unknown * 0x0008
+			| masked_area_partially_visible * 0x0010 | fixed_player_settings * 0x0020 | custom_forces * 0x0040 | custom_techtree * 0x0080
+			| custom_abilities * 0x0100 | custom_upgrades * 0x0200 | unknown2 * 0x0400 | cliff_shore_waves * 0x0800
+			| rolling_shore_waves * 0x1000 | unknown3 * 0x2000 | unknown4 * 0x4000 | item_classification * 0x8000 | water_tinting * 0x10000
+			| accurate_probability_for_calculations * 0x20000 | custom_ability_skins * 0x40000 | disable_deny_icon * 0x80000
+			| force_default_zoom * 0x100000 | force_max_zoom * 0x200000 | force_min_zoom * 0x400000;
 
 		writer.write(flags);
 
@@ -486,7 +469,8 @@ export class MapInfo {
 
 		writer.write<uint32_t>(forces.size());
 		for (const auto& i : forces) {
-			const uint32_t force_flags = i.allied * 0b00000001 | i.allied_victory * 0b00000010 | i.share_vision * 0b00000100 | i.share_unit_control * 0b00010000 | i.share_advanced_unit_control * 0b00100000;
+			const uint32_t force_flags = i.allied * 0b00000001 | i.allied_victory * 0b00000010 | i.share_vision * 0b00000100
+				| i.share_unit_control * 0b00010000 | i.share_advanced_unit_control * 0b00100000;
 			writer.write(force_flags);
 
 			writer.write(i.player_masks);

--- a/src/base/pathing_map.ixx
+++ b/src/base/pathing_map.ixx
@@ -274,4 +274,73 @@ export class PathingMap {
 		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	}
+
+	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
+        const int new_width = width + delta_left + delta_right;
+        const int new_height = height + delta_top + delta_bottom;
+
+		// sanity check
+		if (new_width <= 0 || new_height <= 0) {
+			return;
+		}
+		
+		if (new_width % 4 != 0 || new_height % 4 != 0) {
+			return;
+		}
+
+		// store old data and dimensions
+		std::vector<uint8_t> old_static = std::move(pathing_cells_static);
+		std::vector<uint8_t> old_dynamic = std::move(pathing_cells_dynamic);
+		const int old_width = width;
+		const int old_height = height;
+
+		// create new vectors with new dimensions
+		pathing_cells_static.resize(new_width * new_height);
+		pathing_cells_dynamic.resize(new_width * new_height);
+
+		// copy old data to new, with padding/trimming
+		for (int y = 0; y < new_height; y++) {
+			for (int x = 0; x < new_width; x++) {
+				// calculate source coordinates in old array
+				int src_x = x - delta_left;
+				int src_y = y - delta_bottom;
+
+				// clamp to old map boundaries for padding
+				// this handles both padding (uses edge values) and trimming (offsets source)
+				src_x = std::clamp(src_x, 0, old_width - 1);
+				src_y = std::clamp(src_y, 0, old_height - 1);
+
+				// copy from old to new
+				const int old_index = src_y * old_width + src_x;
+				const int new_index = y * new_width + x;
+
+				pathing_cells_static[new_index] = old_static[old_index];
+				pathing_cells_dynamic[new_index] = old_dynamic[old_index];
+			}
+		}
+
+		// update dimensions
+		width = new_width;
+		height = new_height;
+
+		// recreate textures with new data
+		glDeleteTextures(1, &texture_static);
+		glCreateTextures(GL_TEXTURE_2D, 1, &texture_static);
+		glTextureStorage2D(texture_static, 1, GL_R8UI, width, height);
+		glTextureSubImage2D(texture_static, 0, 0, 0, width, height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, pathing_cells_static.data());
+		glTextureParameteri(texture_static, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTextureParameteri(texture_static, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		glDeleteTextures(1, &texture_dynamic);
+		glCreateTextures(GL_TEXTURE_2D, 1, &texture_dynamic);
+		glTextureStorage2D(texture_dynamic, 1, GL_R8UI, width, height);
+		const uint8_t clear_color = 0;
+		glClearTexImage(texture_dynamic, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &clear_color);
+		glTextureParameteri(texture_dynamic, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+		glTextureParameteri(texture_dynamic, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
 };

--- a/src/base/pathing_map.ixx
+++ b/src/base/pathing_map.ixx
@@ -24,10 +24,14 @@ export class PathingMap {
 		unwalkable = 0b00000010,
 		unflyable = 0b00000100,
 		unbuildable = 0b00001000,
+		harvestable = 0b00010000,
+		blight = 0b00100000,
+		water = 0b01000000,
+		amphibious = 0b10000000
 	};
 
-	GLuint texture_static;
-	GLuint texture_dynamic;
+	GLuint texture_static = 0;
+	GLuint texture_dynamic = 0;
 	std::vector<uint8_t> pathing_cells_static;
 	std::vector<uint8_t> pathing_cells_dynamic;
 
@@ -55,22 +59,7 @@ export class PathingMap {
 		pathing_cells_static = reader.read_vector<uint8_t>(width * height);
 		pathing_cells_dynamic.resize(width * height);
 
-		glCreateTextures(GL_TEXTURE_2D, 1, &texture_static);
-		glTextureStorage2D(texture_static, 1, GL_R8UI, width, height);
-		glTextureSubImage2D(texture_static, 0, 0, 0, width, height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, pathing_cells_static.data());
-		glTextureParameteri(texture_static, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_static, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glCreateTextures(GL_TEXTURE_2D, 1, &texture_dynamic);
-		glTextureStorage2D(texture_dynamic, 1, GL_R8UI, width, height);
-		constexpr uint8_t clear_color = 0;
-		glClearTexImage(texture_dynamic, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &clear_color);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		recreate_textures();
 
 		return true;
 	}
@@ -261,24 +250,7 @@ export class PathingMap {
 		pathing_cells_static.resize(width * height);
 		pathing_cells_dynamic.resize(width * height);
 
-		glDeleteTextures(1, &texture_static);
-		glCreateTextures(GL_TEXTURE_2D, 1, &texture_static);
-		glTextureStorage2D(texture_static, 1, GL_R8UI, width, height);
-		glTextureSubImage2D(texture_static, 0, 0, 0, width, height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, pathing_cells_static.data());
-		glTextureParameteri(texture_static, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_static, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		glDeleteTextures(1, &texture_dynamic);
-		glCreateTextures(GL_TEXTURE_2D, 1, &texture_dynamic);
-		glTextureStorage2D(texture_dynamic, 1, GL_R8UI, width, height);
-		const uint8_t clear_color = 0;
-		glClearTexImage(texture_dynamic, 0, GL_RED_INTEGER, GL_UNSIGNED_BYTE, &clear_color);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		glTextureParameteri(texture_dynamic, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		recreate_textures();
 	}
 
 	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
@@ -330,7 +302,14 @@ export class PathingMap {
 		height = new_height;
 
 		// recreate textures with new data
-		glDeleteTextures(1, &texture_static);
+		recreate_textures();
+	}
+
+  private:
+	void recreate_textures() {
+		if (texture_static != 0) {
+			glDeleteTextures(1, &texture_static);
+		}
 		glCreateTextures(GL_TEXTURE_2D, 1, &texture_static);
 		glTextureStorage2D(texture_static, 1, GL_R8UI, width, height);
 		glTextureSubImage2D(texture_static, 0, 0, 0, width, height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, pathing_cells_static.data());
@@ -339,7 +318,9 @@ export class PathingMap {
 		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTextureParameteri(texture_static, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-		glDeleteTextures(1, &texture_dynamic);
+		if (texture_dynamic != 0) {
+			glDeleteTextures(1, &texture_dynamic);
+		}
 		glCreateTextures(GL_TEXTURE_2D, 1, &texture_dynamic);
 		glTextureStorage2D(texture_dynamic, 1, GL_R8UI, width, height);
 		const uint8_t clear_color = 0;

--- a/src/base/pathing_map.ixx
+++ b/src/base/pathing_map.ixx
@@ -133,7 +133,13 @@ export class PathingMap {
 	/// Checks for every cell on the supplied pathing_texture where (pathing_texture & mask == true) whether (existing_pathing & mask == true) and if so returns false
 	/// Expects position in whole grid tiles
 	/// Rotation in multiples of 90
-	[[nodiscard]] bool is_area_free(const glm::vec2 position, const int rotation, const std::shared_ptr<PathingTexture>& pathing_texture, const uint8_t mask) const {
+	[[nodiscard]]
+	bool is_area_free(
+		const glm::vec2 position,
+		const int rotation,
+		const std::shared_ptr<PathingTexture>& pathing_texture,
+		const uint8_t mask
+	) const {
 		const int div_w = (rotation % 180) ? pathing_texture->height : pathing_texture->width;
 		const int div_h = (rotation % 180) ? pathing_texture->width : pathing_texture->height;
 		for (int j = 0; j < pathing_texture->height; j++) {
@@ -276,14 +282,14 @@ export class PathingMap {
 	}
 
 	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
-        const int new_width = width + delta_left + delta_right;
-        const int new_height = height + delta_top + delta_bottom;
+		const int new_width = width + delta_left + delta_right;
+		const int new_height = height + delta_top + delta_bottom;
 
 		// sanity check
 		if (new_width <= 0 || new_height <= 0) {
 			return;
 		}
-		
+
 		if (new_width % 4 != 0 || new_height % 4 != 0) {
 			return;
 		}

--- a/src/base/regions.ixx
+++ b/src/base/regions.ixx
@@ -5,7 +5,7 @@ import BinaryReader;
 import Hierarchy;
 import <glm/glm.hpp>;
 
-struct Region {
+export struct Region {
 	float left;
 	float right;
 	float top;

--- a/src/base/regions.ixx
+++ b/src/base/regions.ixx
@@ -23,7 +23,7 @@ export class Regions {
   public:
 	std::vector<Region> regions;
 
-	bool load() {
+	bool load(float terrain_offset_x, float terrain_offset_y) {
 		BinaryReader reader = hierarchy.map_file_read("war3map.w3r").value();
 
 		const int version = reader.read<uint32_t>();
@@ -33,10 +33,13 @@ export class Regions {
 
 		regions.resize(reader.read<uint32_t>());
 		for (auto& i : regions) {
-			i.left = reader.read<float>();
-			i.bottom = reader.read<float>();
-			i.right = reader.read<float>();
-			i.top = reader.read<float>();
+			// change coordinate system to [0, terrain_width] x [0, terrain_height]
+			// as used by other objects in HiveWE
+			i.left = (reader.read<float>() - terrain_offset_x) / 128.f;
+			i.bottom = (reader.read<float>() - terrain_offset_y) / 128.f;
+			i.right = (reader.read<float>() - terrain_offset_x) / 128.f;
+			i.top = (reader.read<float>() - terrain_offset_y) / 128.f;
+
 			i.name = reader.read_c_string();
 			i.creation_number = reader.read<int>();
 			i.weather_id = reader.read_string(4);
@@ -57,5 +60,16 @@ export class Regions {
 		// writer.write_vector<uint8_t>(pathing_cells_static);
 
 		//	hierarchy.map_file_write("war3map.wpr", writer.buffer);
+	}
+
+	void remove_region(Region* region) {
+		const auto iterator = regions.begin() + std::distance(regions.data(), region);
+		regions.erase(iterator);
+	}
+
+	void remove_regions(const std::unordered_set<Region*>& list) {
+		std::erase_if(regions, [&](Region& region) {
+			return list.contains(&region);
+		});
 	}
 };

--- a/src/base/shadow_map.ixx
+++ b/src/base/shadow_map.ixx
@@ -13,7 +13,7 @@ export class ShadowMap {
 	GLuint texture;
 	std::vector<u8> cells;
 
-private:
+  private:
 	void update_texture() {
 		glCreateTextures(GL_TEXTURE_2D, 1, &texture);
 		glTextureStorage2D(texture, 1, GL_R8UI, width, height);
@@ -24,8 +24,7 @@ private:
 		glTextureParameteri(texture, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 	}
 
-public:
-
+  public:
 	bool load(size_t terrain_width, size_t terrain_height) {
 		BinaryReader reader = hierarchy.map_file_read("war3map.shd").value();
 
@@ -36,7 +35,7 @@ public:
 		const size_t expected_size = width * height;
 		const size_t file_size = reader.buffer.size();
 		if (file_size != expected_size) {
-			std::println("Error: Shadow map file size mismatch!");	
+			std::println("Error: Shadow map file size mismatch!");
 			cells.resize(expected_size, 0);
 		} else {
 			cells = reader.read_vector<u8>(expected_size);
@@ -55,7 +54,7 @@ public:
 		width = new_width;
 		height = new_height;
 		cells.resize(width * height, 0);
-		
+
 		glDeleteTextures(1, &texture);
 		update_texture();
 	}
@@ -63,15 +62,15 @@ public:
 	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
 		size_t new_width = static_cast<size_t>(static_cast<int>(width) + delta_left + delta_right);
 		size_t new_height = static_cast<size_t>(static_cast<int>(height) + delta_top + delta_bottom);
-		
+
 		std::vector<u8> new_cells(new_width * new_height, 0);
-		
+
 		// copy old data to new position
 		for (size_t y = 0; y < height; ++y) {
 			for (size_t x = 0; x < width; ++x) {
 				int new_x = static_cast<int>(x) + delta_left;
 				int new_y = static_cast<int>(y) + delta_top;
-				
+
 				// only copy if the new position is within bounds
 				if (new_x >= 0 && new_x < static_cast<int>(new_width) && new_y >= 0 && new_y < static_cast<int>(new_height)) {
 					size_t old_index = y * width + x;
@@ -80,11 +79,11 @@ public:
 				}
 			}
 		}
-		
+
 		width = new_width;
 		height = new_height;
 		cells = std::move(new_cells);
-		
+
 		glDeleteTextures(1, &texture);
 		update_texture();
 	}

--- a/src/base/shadow_map.ixx
+++ b/src/base/shadow_map.ixx
@@ -13,12 +13,8 @@ export class ShadowMap {
 	GLuint texture;
 	std::vector<u8> cells;
 
-	bool load(BinaryReader& reader, size_t terrain_width, size_t terrain_height) {
-		width = terrain_width * 4;
-		height = terrain_height * 4;
-
-		cells = reader.read_vector<u8>(width * height);
-
+private:
+	void update_texture() {
 		glCreateTextures(GL_TEXTURE_2D, 1, &texture);
 		glTextureStorage2D(texture, 1, GL_R8UI, width, height);
 		glTextureSubImage2D(texture, 0, 0, 0, width, height, GL_RED_INTEGER, GL_UNSIGNED_BYTE, cells.data());
@@ -26,6 +22,27 @@ export class ShadowMap {
 		glTextureParameteri(texture, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
 		glTextureParameteri(texture, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
 		glTextureParameteri(texture, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+	}
+
+public:
+
+	bool load(size_t terrain_width, size_t terrain_height) {
+		BinaryReader reader = hierarchy.map_file_read("war3map.shd").value();
+
+		width = terrain_width * 4;
+		height = terrain_height * 4;
+
+		// check if the shadow map is correct size
+		const size_t expected_size = width * height;
+		const size_t file_size = reader.buffer.size();
+		if (file_size != expected_size) {
+			std::println("Error: Shadow map file size mismatch!");	
+			cells.resize(expected_size, 0);
+		} else {
+			cells = reader.read_vector<u8>(expected_size);
+		}
+
+		update_texture();
 
 		return true;
 	}
@@ -34,7 +51,41 @@ export class ShadowMap {
 		hierarchy.map_file_write("war3map.shd", cells);
 	}
 
-	void resize(size_t width, size_t height) {
-	
+	void resize(size_t new_width, size_t new_height) {
+		width = new_width;
+		height = new_height;
+		cells.resize(width * height, 0);
+		
+		glDeleteTextures(1, &texture);
+		update_texture();
+	}
+
+	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom) {
+		size_t new_width = static_cast<size_t>(static_cast<int>(width) + delta_left + delta_right);
+		size_t new_height = static_cast<size_t>(static_cast<int>(height) + delta_top + delta_bottom);
+		
+		std::vector<u8> new_cells(new_width * new_height, 0);
+		
+		// copy old data to new position
+		for (size_t y = 0; y < height; ++y) {
+			for (size_t x = 0; x < width; ++x) {
+				int new_x = static_cast<int>(x) + delta_left;
+				int new_y = static_cast<int>(y) + delta_top;
+				
+				// only copy if the new position is within bounds
+				if (new_x >= 0 && new_x < static_cast<int>(new_width) && new_y >= 0 && new_y < static_cast<int>(new_height)) {
+					size_t old_index = y * width + x;
+					size_t new_index = static_cast<size_t>(new_y) * new_width + static_cast<size_t>(new_x);
+					new_cells[new_index] = cells[old_index];
+				}
+			}
+		}
+		
+		width = new_width;
+		height = new_height;
+		cells = std::move(new_cells);
+		
+		glDeleteTextures(1, &texture);
+		update_texture();
 	}
 };

--- a/src/base/shadow_map.ixx
+++ b/src/base/shadow_map.ixx
@@ -63,26 +63,9 @@ export class ShadowMap {
 		size_t new_width = static_cast<size_t>(static_cast<int>(width) + delta_left + delta_right);
 		size_t new_height = static_cast<size_t>(static_cast<int>(height) + delta_top + delta_bottom);
 
-		std::vector<u8> new_cells(new_width * new_height, 0);
-
-		// copy old data to new position
-		for (size_t y = 0; y < height; ++y) {
-			for (size_t x = 0; x < width; ++x) {
-				int new_x = static_cast<int>(x) + delta_left;
-				int new_y = static_cast<int>(y) + delta_top;
-
-				// only copy if the new position is within bounds
-				if (new_x >= 0 && new_x < static_cast<int>(new_width) && new_y >= 0 && new_y < static_cast<int>(new_height)) {
-					size_t old_index = y * width + x;
-					size_t new_index = static_cast<size_t>(new_y) * new_width + static_cast<size_t>(new_x);
-					new_cells[new_index] = cells[old_index];
-				}
-			}
-		}
-
 		width = new_width;
 		height = new_height;
-		cells = std::move(new_cells);
+		cells.resize(width * height, 0);
 
 		glDeleteTextures(1, &texture);
 		update_texture();

--- a/src/base/sounds.ixx
+++ b/src/base/sounds.ixx
@@ -94,6 +94,5 @@ export class Sounds {
 		}
 	}
 
-	void save() const {
-	}
+	void save() const {}
 };

--- a/src/base/terrain.ixx
+++ b/src/base/terrain.ixx
@@ -80,6 +80,28 @@ export class Terrain : public QObject {
 
 	static constexpr int write_version = 12;
 
+	// total sum 570
+	static constexpr std::tuple<int, int> variation_chances[18] = {
+		{ 0, 85 },
+		{ 16, 85 },
+		{ 0, 85 },
+		{ 1, 10 },
+		{ 2, 4 },
+		{ 3, 1 },
+		{ 4, 85 },
+		{ 5, 10 },
+		{ 6, 4 },
+		{ 7, 1 },
+		{ 8, 85 },
+		{ 9, 10 },
+		{ 10, 4 },
+		{ 11, 1 },
+		{ 12, 85 },
+		{ 13, 10 },
+		{ 14, 4 },
+		{ 15, 1 }
+	};
+
 	// Sequential versions for GPU uploading
 	std::vector<float> ground_heights;
 	std::vector<float> final_ground_heights;
@@ -1117,8 +1139,296 @@ public:
         //map->physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
     }
 
+    /// Computes the terrain pathing flags for the target cell. 
+    /// Takes cliffs, blight, water, terrain textures and boundaries into account
+    uint8_t get_terrain_pathing(size_t i, size_t j) {        
+        // Use floor division to correctly map pathing cells to corners
+        int corner_x = static_cast<int>(std::floor(i / 4.0));
+        int corner_y = static_cast<int>(std::floor(j / 4.0));
+        const Corner& bottom_left = corners[corner_x][corner_y];
+
+        // take terrain texture into account (from the closest corner)
+        int x = static_cast<int>(std::round(i / 4.0));
+        int y = static_cast<int>(std::round(j / 4.0));
+        const Corner& closest_corner = corners[x][y];
+        uint8_t mask = pathing_options[tileset_ids[closest_corner.ground_texture]].mask();
+
+        // cliffs are unbuildable and unwalkable
+        if (bottom_left.cliff) {
+            mask |= PathingMap::unbuildable | PathingMap::unwalkable;
+        } 
+        
+        // take blight into account
+        if (closest_corner.blight) {
+            mask |= 0b00100000;
+        }
+
+        // take water into account
+        if (closest_corner.water) {
+            // apply water mask
+            mask |= 0b01000000;
+
+            if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height() + 0.40) {
+                // deep water is unwalkable and unbuildable
+                mask |= PathingMap::unbuildable | PathingMap::unwalkable;
+            } else if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height()) {
+                // shallow water is unbuildable
+                mask |= PathingMap::unbuildable;
+            }
+        }
+
+        // boundaries and map edges are unwalkable, unflyable and unbuildable¸
+        // NOTE: game handles corners/boundaries differently
+        // if the bottom-left corner is a boundary, then the entire 4x4 cell is considered a boundary
+        if (bottom_left.map_edge || bottom_left.boundary) {
+            mask |= PathingMap::unbuildable | PathingMap::unflyable | PathingMap::unwalkable;
+        }
+
+        // Debug print
+        /*std::cout << "Pathing[" << i << "," << j << "] -> corner[" << x << "," << y << "] "
+                  << "tex:" << corner.ground_texture << " cliff:" << corner.cliff << " water:" << corner.water 
+                  << " blight:" << corner.blight << " | bottom_left[" << i/4 << "," << j/4 << "] "
+                  << "edge:" << bottom_left.map_edge << " boundary:" << bottom_left.boundary 
+                  << " | mask:" << std::hex << (int)mask << std::dec << std::endl;*/
+
+        return mask;
+    }
+
+    /// Updates the map_edge flags (shadows on the edges of the map) 
+    void set_unplayable_boundaries(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
+        // places "shadows" on the edges of the map
+        for (size_t i = 0; i < width; i++) {
+            for (size_t j = 0; j < height; j++) {
+                bool is_boundary = false;
+                
+                // check all bounduaries
+                if (i < unplayable_left) {
+                    is_boundary = true;
+                }
+                else if (i >= width - unplayable_right) {
+                    is_boundary = true;
+                }
+                else if (j < unplayable_bottom) {
+                    is_boundary = true;
+                }
+                else if (j >= height - unplayable_top) {
+                    is_boundary = true;
+                }
+                
+                corners[i][j].map_edge = is_boundary;
+            }
+        }
+
+        emit minimap_changed(minimap_image());
+    }
+
+    /// Resizes the terrain by expanding/shrinking it from all four sides
+    void resize(int delta_left, int delta_right, int delta_top, int delta_bottom, Physics& physics) {
+        const int new_width = width + delta_left + delta_right;
+        const int new_height = height + delta_top + delta_bottom;
+
+        // width/height must be at least 33
+        if (new_width < 33 || new_height < 33) {
+            return;
+        }
+
+        // maximum map size supported by wc3 is 481 x 481
+        if (new_width > 481 || new_height > 481) {
+            return;
+        }
+
+        // sanity check, (size - 1) must be multiple of 32
+        if (new_width % 32 != 1  || new_height % 32 != 1) {
+            return;
+        }
+
+        // create and setup
+        std::vector<std::vector<Corner>> new_corners = resize_corners(delta_left, delta_right, delta_top, delta_bottom);
+
+        // update terrain object
+        width = new_width;
+        height = new_height;
+        corners = new_corners;
+        offset.x -= delta_left * 128;
+        offset.y -= delta_bottom * 128;
+
+        re_render(physics);
+
+        emit minimap_changed(minimap_image());
+    }
+
     void update_minimap() {
         emit minimap_changed(minimap_image());
+    }
+
+    static int get_random_variation() {
+        std::random_device rd;
+        std::mt19937 e2(rd());
+        std::uniform_int_distribution<> dist(0, 570);
+
+        int nr = dist(e2) - 1;
+
+        for (auto&&[variation, chance] : variation_chances) {
+            if (nr < chance) {
+                return variation;
+            }
+            nr -= chance;
+        }
+        assert("Didn't hit the list of tile variations");
+        return 0;
+    }
+
+private:
+    Corner create_default_corner() const {
+        // creates a corner with default values, used when resize destroys the original terrain
+        Corner corner;
+
+        corner.map_edge = false;
+
+        corner.ramp = false;
+        corner.blight = false;
+        corner.water = false;
+        corner.boundary = false;
+        corner.cliff = false;
+        corner.special_doodad = false;
+
+        corner.layer_height = 2;
+        corner.cliff_texture = 15;
+        corner.cliff_variation = 0;
+
+        corner.height = 0;
+        corner.water_height = 0;
+
+        corner.ground_texture = 0;
+
+        return corner;
+    }
+
+    std::vector<std::vector<Corner>> resize_corners(int delta_left, int delta_right, int delta_top, int delta_bottom) const {
+        const int new_width = width + delta_left + delta_right;
+        const int new_height = height + delta_top + delta_bottom;
+
+        // initialise new corner vector
+        std::vector<std::vector<Corner>> new_corners(new_width, std::vector<Corner>(new_height));
+
+        // check if all old corners would be removed
+        int old_width_remaining = (int)width + std::min(0, delta_left) + std::min(0, delta_right);
+        int old_height_remaining = (int)height + std::min(0, delta_bottom) + std::min(0, delta_top);
+        if (old_width_remaining <= 0 || old_height_remaining <= 0) {
+            // all old corners deleted, fill with default
+            Corner default_corner = create_default_corner();
+            for (size_t i = 0; i < new_width; i++) {
+                for (size_t j = 0; j < new_height; j++) {
+                    // apply random tile variation and fix map_edge flag
+                    default_corner.ground_variation = get_random_variation();
+                    default_corner.map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
+                    new_corners[i][j] = default_corner;
+                }
+            }
+            return new_corners;
+        }
+
+        // fill the new corners by mapping from old corners
+        for (size_t i = 0; i < new_width; i++) {
+            for (size_t j = 0; j < new_height; j++) {
+                // map new position to old position
+                int old_i = (int)i - delta_left;
+                int old_j = (int)j - delta_bottom;
+                
+                // check if this is an old corner (before clamping)
+                bool is_old_corner = (old_i >= 0 && old_i < (int)width && old_j >= 0 && old_j < (int)height);
+                
+                // clamp to valid old range
+                old_i = std::clamp(old_i, 0, (int)width - 1);
+                old_j = std::clamp(old_j, 0, (int)height - 1);
+                
+                new_corners[i][j] = corners[old_i][old_j];
+                
+                // fix map_edge flag for all corners
+                //new_corners[i][j].map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
+                
+                // apply random variations and fix special_doodad for NEW corners
+                if (!is_old_corner) {
+                    new_corners[i][j].special_doodad = false;
+                    new_corners[i][j].ground_variation = get_random_variation();
+                }
+            }
+        }
+
+        return new_corners;
+    }
+
+    void re_render(Physics& physics) {
+        // clear old buffers
+        glDeleteBuffers(1, &ground_height_buffer);
+        glDeleteBuffers(1, &cliff_level_buffer);
+        glDeleteBuffers(1, &water_height_buffer);
+        glDeleteBuffers(1, &ground_texture_data_buffer);
+        glDeleteBuffers(1, &ground_exists_buffer);
+        glDeleteBuffers(1, &water_exists_buffer);
+
+        // clear all cliffs (this prevents out of bounds error when shrinking terrain)
+        cliffs.clear();
+
+        // clear romp flags on all corners
+        for (int i = 0; i < width; i++) {
+            for (int j = 0; j < height; j++) {
+                corners[i][j].romp = false;
+            }
+        }
+
+        // resize GPU buffer vectors
+        ground_heights.resize(width * height);
+        final_ground_heights.resize(width * height);
+        ground_texture_list.resize((width - 1) * (height - 1));
+        ground_exists_data.resize(width * height);
+        water_heights.resize(width * height);
+        water_exists_data.resize(width * height);
+
+        // determine cliff flags for all corners
+        for (int i = 0; i < width - 1; i++) {
+            for (int j = 0; j < height - 1; j++) {
+                Corner& bottom_left = corners[i][j];
+                Corner& bottom_right = corners[i + 1][j];
+                Corner& top_left = corners[i][j + 1];
+                Corner& top_right = corners[i + 1][j + 1];
+
+                bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
+                    || bottom_left.layer_height != top_left.layer_height
+                    || bottom_left.layer_height != top_right.layer_height;
+            }
+        }
+
+        // recreate GPU buffers with new size
+        glCreateBuffers(1, &ground_height_buffer);
+        glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+        glCreateBuffers(1, &cliff_level_buffer);
+        glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+        glCreateBuffers(1, &ground_texture_data_buffer);
+        glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
+        glCreateBuffers(1, &ground_exists_buffer);
+        glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+        glCreateBuffers(1, &water_height_buffer);
+        glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+        glCreateBuffers(1, &water_exists_buffer);
+        glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+
+        // update everything else
+        update_ground_heights({ 0, 0, width, height });
+        update_ground_textures({ 0, 0, width - 1, height - 1 });
+        update_cliff_meshes({ 0, 0, width - 1, height - 1 });
+        update_water({ 0, 0, width, height });
+
+        // update physics collision shapeated)
+        physics.dynamicsWorld->removeRigidBody(collision_body);
+        delete collision_body;
+        delete collision_shape;
+
+        collision_shape = new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
+        collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
+        collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f));
+        collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
+        physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
     }
 
 signals:

--- a/src/base/terrain.ixx
+++ b/src/base/terrain.ixx
@@ -1184,13 +1184,6 @@ public:
             mask |= PathingMap::unbuildable | PathingMap::unflyable | PathingMap::unwalkable;
         }
 
-        // Debug print
-        /*std::cout << "Pathing[" << i << "," << j << "] -> corner[" << x << "," << y << "] "
-                  << "tex:" << corner.ground_texture << " cliff:" << corner.cliff << " water:" << corner.water 
-                  << " blight:" << corner.blight << " | bottom_left[" << i/4 << "," << j/4 << "] "
-                  << "edge:" << bottom_left.map_edge << " boundary:" << bottom_left.boundary 
-                  << " | mask:" << std::hex << (int)mask << std::dec << std::endl;*/
-
         return mask;
     }
 

--- a/src/base/terrain.ixx
+++ b/src/base/terrain.ixx
@@ -52,13 +52,13 @@ export struct Corner {
 	int cliff_texture;
 	int layer_height;
 
-    float final_ground_height() const {
-        return height + layer_height - 2.0;
-    }
+	float final_ground_height() const {
+		return height + layer_height - 2.0;
+	}
 
-    float final_water_height(const float water_offset) const {
-        return water_height + water_offset;
-    }
+	float final_water_height(const float water_offset) const {
+		return water_height + water_offset;
+	}
 };
 
 export struct TilePathingg {
@@ -75,31 +75,31 @@ export struct TilePathingg {
 	}
 };
 
-export class Terrain : public QObject {
+export class Terrain: public QObject {
 	Q_OBJECT
 
 	static constexpr int write_version = 12;
 
 	// total sum 570
 	static constexpr std::tuple<int, int> variation_chances[18] = {
-		{ 0, 85 },
-		{ 16, 85 },
-		{ 0, 85 },
-		{ 1, 10 },
-		{ 2, 4 },
-		{ 3, 1 },
-		{ 4, 85 },
-		{ 5, 10 },
-		{ 6, 4 },
-		{ 7, 1 },
-		{ 8, 85 },
-		{ 9, 10 },
-		{ 10, 4 },
-		{ 11, 1 },
-		{ 12, 85 },
-		{ 13, 10 },
-		{ 14, 4 },
-		{ 15, 1 }
+		{0, 85},
+		{16, 85},
+		{0, 85},
+		{1, 10},
+		{2, 4},
+		{3, 1},
+		{4, 85},
+		{5, 10},
+		{6, 4},
+		{7, 1},
+		{8, 85},
+		{9, 10},
+		{10, 4},
+		{11, 1},
+		{12, 85},
+		{13, 10},
+		{14, 4},
+		{15, 1}
 	};
 
 	// Sequential versions for GPU uploading
@@ -114,7 +114,8 @@ export class Terrain : public QObject {
 
 	btHeightfieldTerrainShape* collision_shape;
 	btRigidBody* collision_body;
-public:
+
+  public:
 	char tileset;
 	std::vector<std::string> tileset_ids;
 	std::vector<std::string> cliffset_ids;
@@ -182,1249 +183,1301 @@ public:
 	GLuint water_texture_array;
 
 	~Terrain() {
-        glDeleteTextures(1, &cliff_texture_array);
-        glDeleteTextures(1, &water_texture_array);
+		glDeleteTextures(1, &cliff_texture_array);
+		glDeleteTextures(1, &water_texture_array);
 
-        glDeleteBuffers(1, &ground_height_buffer);
-        glDeleteBuffers(1, &cliff_level_buffer);
-        glDeleteBuffers(1, &water_height_buffer);
-        glDeleteBuffers(1, &ground_texture_data_buffer);
-        glDeleteBuffers(1, &ground_exists_buffer);
-        glDeleteBuffers(1, &water_exists_buffer);
+		glDeleteBuffers(1, &ground_height_buffer);
+		glDeleteBuffers(1, &cliff_level_buffer);
+		glDeleteBuffers(1, &water_height_buffer);
+		glDeleteBuffers(1, &ground_texture_data_buffer);
+		glDeleteBuffers(1, &ground_exists_buffer);
+		glDeleteBuffers(1, &water_exists_buffer);
 
-        //map->physics.dynamicsWorld->removeRigidBody(collision_body);
-        //delete collision_body;
-        //delete collision_shape;
-    }
+		//map->physics.dynamicsWorld->removeRigidBody(collision_body);
+		//delete collision_body;
+		//delete collision_shape;
+	}
 
-    bool load(Physics& physics) {
-        BinaryReader reader = hierarchy.map_file_read("war3map.w3e").value();
+	bool load(Physics& physics) {
+		BinaryReader reader = hierarchy.map_file_read("war3map.w3e").value();
 
-        const std::string magic_number = reader.read_string(4);
-        if (magic_number != "W3E!") {
-            std::cout << "Invalid war3map.w3e file: Magic number is not W3E!" << std::endl;
-            return false;
-        }
+		const std::string magic_number = reader.read_string(4);
+		if (magic_number != "W3E!") {
+			std::cout << "Invalid war3map.w3e file: Magic number is not W3E!" << std::endl;
+			return false;
+		}
 
-        const uint32_t version = reader.read<uint32_t>();
+		const uint32_t version = reader.read<uint32_t>();
 
-        tileset = reader.read<char>();
-        reader.advance(4); // Custom tileset
+		tileset = reader.read<char>();
+		reader.advance(4); // Custom tileset
 
-        const uint32_t tileset_textures = reader.read<uint32_t>();
-        for (size_t i = 0; i < tileset_textures; i++) {
-            tileset_ids.push_back(reader.read_string(4));
-        }
+		const uint32_t tileset_textures = reader.read<uint32_t>();
+		for (size_t i = 0; i < tileset_textures; i++) {
+			tileset_ids.push_back(reader.read_string(4));
+		}
 
-        const int cliffset_textures = reader.read<uint32_t>();
-        for (int i = 0; i < cliffset_textures; i++) {
-            cliffset_ids.push_back(reader.read_string(4));
-        }
+		const int cliffset_textures = reader.read<uint32_t>();
+		for (int i = 0; i < cliffset_textures; i++) {
+			cliffset_ids.push_back(reader.read_string(4));
+		}
 
-        width = reader.read<uint32_t>();
-        height = reader.read<uint32_t>();
+		width = reader.read<uint32_t>();
+		height = reader.read<uint32_t>();
 
-        offset = reader.read<glm::vec2>();
+		offset = reader.read<glm::vec2>();
 
-        // Parse all tilepoints
-        corners.resize(width, std::vector<Corner>(height));
-        for (int j = 0; j < height; j++) {
-            for (int i = 0; i < width; i++) {
-                Corner& corner = corners[i][j];
+		// Parse all tilepoints
+		corners.resize(width, std::vector<Corner>(height));
+		for (int j = 0; j < height; j++) {
+			for (int i = 0; i < width; i++) {
+				Corner& corner = corners[i][j];
 
-                corners[i][j].height = (reader.read<uint16_t>() - 8192.f) / 512.f;
+				corners[i][j].height = (reader.read<uint16_t>() - 8192.f) / 512.f;
 
-                const uint16_t water_and_edge = reader.read<uint16_t>();
-                corners[i][j].water_height = ((water_and_edge & 0x3FFF) - 8192.f) / 512.f;
-                corner.map_edge = water_and_edge & 0x4000;
+				const uint16_t water_and_edge = reader.read<uint16_t>();
+				corners[i][j].water_height = ((water_and_edge & 0x3FFF) - 8192.f) / 512.f;
+				corner.map_edge = water_and_edge & 0x4000;
 
-                if (version >= 12 ) {
-                    const uint16_t texture_and_flags = reader.read<uint16_t>();
-                    corner.ground_texture = texture_and_flags & 0b00'0000'0011'1111;
+				if (version >= 12) {
+					const uint16_t texture_and_flags = reader.read<uint16_t>();
+					corner.ground_texture = texture_and_flags & 0b00'0000'0011'1111;
 
-                    corner.ramp = texture_and_flags & 0b00'0100'0000;
-                    corner.blight = texture_and_flags & 0b00'1000'0000;
-                    corner.water = texture_and_flags & 0b01'0000'0000;
-                    corner.boundary = texture_and_flags & 0b10'0000'0000;
-                } else {
-                    const uint8_t texture_and_flags = reader.read<uint8_t>();
-                    corner.ground_texture = texture_and_flags & 0b0000'1111;
+					corner.ramp = texture_and_flags & 0b00'0100'0000;
+					corner.blight = texture_and_flags & 0b00'1000'0000;
+					corner.water = texture_and_flags & 0b01'0000'0000;
+					corner.boundary = texture_and_flags & 0b10'0000'0000;
+				} else {
+					const uint8_t texture_and_flags = reader.read<uint8_t>();
+					corner.ground_texture = texture_and_flags & 0b0000'1111;
 
-                    corner.ramp = texture_and_flags & 0b0001'0000;
-                    corner.blight = texture_and_flags & 0b0010'0000;
-                    corner.water = texture_and_flags & 0b0100'0000;
-                    corner.boundary = texture_and_flags & 0b1000'0000;
-                }
+					corner.ramp = texture_and_flags & 0b0001'0000;
+					corner.blight = texture_and_flags & 0b0010'0000;
+					corner.water = texture_and_flags & 0b0100'0000;
+					corner.boundary = texture_and_flags & 0b1000'0000;
+				}
 
-                const uint8_t variation = reader.read<uint8_t>();
-                corner.ground_variation = variation & 0b0001'1111;
-                corner.cliff_variation = (variation & 0b1110'0000) >> 5;
+				const uint8_t variation = reader.read<uint8_t>();
+				corner.ground_variation = variation & 0b0001'1111;
+				corner.cliff_variation = (variation & 0b1110'0000) >> 5;
 
-                const uint8_t misc = reader.read<uint8_t>();
-                corner.cliff_texture = (misc & 0b1111'0000) >> 4;
-                corner.layer_height = misc & 0b0000'1111;
-            }
-        }
+				const uint8_t misc = reader.read<uint8_t>();
+				corner.cliff_texture = (misc & 0b1111'0000) >> 4;
+				corner.layer_height = misc & 0b0000'1111;
+			}
+		}
 
-        create(physics);
+		create(physics);
 
-        return true;
-    }
+		return true;
+	}
 
-    void create(const Physics& physics) {
-        // Determine if cliff
-        for (int i = 0; i < width - 1; i++) {
-            for (int j = 0; j < height - 1; j++) {
-                Corner& bottom_left = corners[i][j];
-                Corner& bottom_right = corners[i + 1][j];
-                Corner& top_left = corners[i][j + 1];
-                Corner& top_right = corners[i + 1][j + 1];
+	void create(const Physics& physics) {
+		// Determine if cliff
+		for (int i = 0; i < width - 1; i++) {
+			for (int j = 0; j < height - 1; j++) {
+				Corner& bottom_left = corners[i][j];
+				Corner& bottom_right = corners[i + 1][j];
+				Corner& top_left = corners[i][j + 1];
+				Corner& top_right = corners[i + 1][j + 1];
 
-                bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
-                    || bottom_left.layer_height != top_left.layer_height
-                    || bottom_left.layer_height != top_right.layer_height;
-            }
-        }
-        // Done parsing
+				bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
+					|| bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
+			}
+		}
+		// Done parsing
 
-        hierarchy.tileset = tileset;
+		hierarchy.tileset = tileset;
 
-        terrain_slk.load("TerrainArt/Terrain.slk");
-        cliff_slk.load("TerrainArt/CliffTypes.slk");
-        const slk::SLK water_slk("TerrainArt/Water.slk");
+		terrain_slk.load("TerrainArt/Terrain.slk");
+		cliff_slk.load("TerrainArt/CliffTypes.slk");
+		const slk::SLK water_slk("TerrainArt/Water.slk");
 
-        // Water Textures and Colours
+		// Water Textures and Colours
 
-        water_offset = water_slk.data<float>("height", tileset + "Sha"s);
-        water_textures_nr = water_slk.data<int>("numtex", tileset + "Sha"s);
-        animation_rate = water_slk.data<int>("texrate", tileset + "Sha"s);
+		water_offset = water_slk.data<float>("height", tileset + "Sha"s);
+		water_textures_nr = water_slk.data<int>("numtex", tileset + "Sha"s);
+		animation_rate = water_slk.data<int>("texrate", tileset + "Sha"s);
 
-        int red = water_slk.data<int>("smin_r", tileset + "Sha"s);
-        int green = water_slk.data<int>("smin_g", tileset + "Sha"s);
-        int blue = water_slk.data<int>("smin_b", tileset + "Sha"s);
-        int alpha = water_slk.data<int>("smin_a", tileset + "Sha"s);
+		int red = water_slk.data<int>("smin_r", tileset + "Sha"s);
+		int green = water_slk.data<int>("smin_g", tileset + "Sha"s);
+		int blue = water_slk.data<int>("smin_b", tileset + "Sha"s);
+		int alpha = water_slk.data<int>("smin_a", tileset + "Sha"s);
 
-        shallow_color_min = { red, green, blue, alpha };
-        shallow_color_min /= 255.f;
+		shallow_color_min = {red, green, blue, alpha};
+		shallow_color_min /= 255.f;
 
-        red = water_slk.data<int>("smax_r", tileset + "Sha"s);
-        green = water_slk.data<int>("smax_g", tileset + "Sha"s);
-        blue = water_slk.data<int>("smax_b", tileset + "Sha"s);
-        alpha = water_slk.data<int>("smax_a", tileset + "Sha"s);
+		red = water_slk.data<int>("smax_r", tileset + "Sha"s);
+		green = water_slk.data<int>("smax_g", tileset + "Sha"s);
+		blue = water_slk.data<int>("smax_b", tileset + "Sha"s);
+		alpha = water_slk.data<int>("smax_a", tileset + "Sha"s);
 
-        shallow_color_max = { red, green, blue, alpha };
-        shallow_color_max /= 255.f;
+		shallow_color_max = {red, green, blue, alpha};
+		shallow_color_max /= 255.f;
 
-        red = water_slk.data<int>("dmin_r", tileset + "Sha"s);
-        green = water_slk.data<int>("dmin_g", tileset + "Sha"s);
-        blue = water_slk.data<int>("dmin_b", tileset + "Sha"s);
-        alpha = water_slk.data<int>("dmin_a", tileset + "Sha"s);
+		red = water_slk.data<int>("dmin_r", tileset + "Sha"s);
+		green = water_slk.data<int>("dmin_g", tileset + "Sha"s);
+		blue = water_slk.data<int>("dmin_b", tileset + "Sha"s);
+		alpha = water_slk.data<int>("dmin_a", tileset + "Sha"s);
 
-        deep_color_min = { red, green, blue, alpha };
-        deep_color_min /= 255.f;
+		deep_color_min = {red, green, blue, alpha};
+		deep_color_min /= 255.f;
 
-        red = water_slk.data<int>("dmax_r", tileset + "Sha"s);
-        green = water_slk.data<int>("dmax_g", tileset + "Sha"s);
-        blue = water_slk.data<int>("dmax_b", tileset + "Sha"s);
-        alpha = water_slk.data<int>("dmax_a", tileset + "Sha"s);
+		red = water_slk.data<int>("dmax_r", tileset + "Sha"s);
+		green = water_slk.data<int>("dmax_g", tileset + "Sha"s);
+		blue = water_slk.data<int>("dmax_b", tileset + "Sha"s);
+		alpha = water_slk.data<int>("dmax_a", tileset + "Sha"s);
 
-        deep_color_max = { red, green, blue, alpha };
-        deep_color_max /= 255.f;
+		deep_color_max = {red, green, blue, alpha};
+		deep_color_max /= 255.f;
 
-        // Cliff Meshes
-        slk::SLK cliffs_variation_slk("data/warcraft/Cliffs.slk", true);
-        for (size_t i = 0; i < cliffs_variation_slk.rows(); i++) {
-            for (int j = 0; j < cliffs_variation_slk.data<int>("variations", i) + 1; j++) {
-                std::string file_name = "Doodads/Terrain/Cliffs/Cliffs" + cliffs_variation_slk.index_to_row.at(i) + std::to_string(j) + ".mdx";
-                cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
-                path_to_cliff.emplace(cliffs_variation_slk.index_to_row.at(i) + std::to_string(j), static_cast<int>(cliff_meshes.size()) - 1);
-            }
-            cliff_variations.emplace(cliffs_variation_slk.index_to_row.at(i), cliffs_variation_slk.data<int>("variations", i));
-        }
+		// Cliff Meshes
+		slk::SLK cliffs_variation_slk("data/warcraft/Cliffs.slk", true);
+		for (size_t i = 0; i < cliffs_variation_slk.rows(); i++) {
+			for (int j = 0; j < cliffs_variation_slk.data<int>("variations", i) + 1; j++) {
+				std::string file_name =
+					"Doodads/Terrain/Cliffs/Cliffs" + cliffs_variation_slk.index_to_row.at(i) + std::to_string(j) + ".mdx";
+				cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
+				path_to_cliff.emplace(
+					cliffs_variation_slk.index_to_row.at(i) + std::to_string(j),
+					static_cast<int>(cliff_meshes.size()) - 1
+				);
+			}
+			cliff_variations.emplace(cliffs_variation_slk.index_to_row.at(i), cliffs_variation_slk.data<int>("variations", i));
+		}
 
-        // Ground textures
-        for (const auto& tile_id : tileset_ids) {
-            ground_textures.push_back(resource_manager.load<GroundTexture>(terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id)));
-            ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
-        	ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
-        }
-        blight_texture = static_cast<int>(ground_textures.size());
-        ground_texture_to_id.emplace("blight", blight_texture);
-        ground_textures.push_back(resource_manager.load<GroundTexture>(world_edit_data.data("TileSets", std::string(1, tileset), 1)));
+		// Ground textures
+		for (const auto& tile_id : tileset_ids) {
+			ground_textures.push_back(
+				resource_manager.load<GroundTexture>(terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id))
+			);
+			ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
+			ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
+		}
+		blight_texture = static_cast<int>(ground_textures.size());
+		ground_texture_to_id.emplace("blight", blight_texture);
+		ground_textures.push_back(resource_manager.load<GroundTexture>(world_edit_data.data("TileSets", std::string(1, tileset), 1)));
 		ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
 
-        // Cliff Textures
-        for (const auto& cliff_id : cliffset_ids) {
-            cliff_textures.push_back(resource_manager.load<Texture>(cliff_slk.data("texdir", cliff_id) + "/" + cliff_slk.data("texfile", cliff_id)));
-            cliff_texture_size = std::max(cliff_texture_size, cliff_textures.back()->width);
-            cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data<std::string_view>("groundtile", cliff_id)]);
-        }
+		// Cliff Textures
+		for (const auto& cliff_id : cliffset_ids) {
+			cliff_textures.push_back(
+				resource_manager.load<Texture>(cliff_slk.data("texdir", cliff_id) + "/" + cliff_slk.data("texfile", cliff_id))
+			);
+			cliff_texture_size = std::max(cliff_texture_size, cliff_textures.back()->width);
+			cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data<std::string_view>("groundtile", cliff_id)]);
+		}
 
-        // prepare GPU buffers
-        ground_heights.resize(width * height);
-        final_ground_heights.resize(width * height);
-        ground_texture_list.resize((width - 1) * (height - 1));
-        ground_exists_data.resize(width * height);
-        water_heights.resize(width * height);
-        water_exists_data.resize(width * height);
+		// prepare GPU buffers
+		ground_heights.resize(width * height);
+		final_ground_heights.resize(width * height);
+		ground_texture_list.resize((width - 1) * (height - 1));
+		ground_exists_data.resize(width * height);
+		water_heights.resize(width * height);
+		water_exists_data.resize(width * height);
 
-        // Ground
-        glCreateBuffers(1, &ground_height_buffer);
-        glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &cliff_level_buffer);
-        glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &ground_texture_data_buffer);
-        glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		// Ground
+		glCreateBuffers(1, &ground_height_buffer);
+		glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &cliff_level_buffer);
+		glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &ground_texture_data_buffer);
+		glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
 		glCreateBuffers(1, &ground_texture_handle_buffer);
-		glNamedBufferStorage(ground_texture_handle_buffer, ground_texture_handles.size() * sizeof(GLuint64), ground_texture_handles.data(), GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &ground_exists_buffer);
-        glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glNamedBufferStorage(
+			ground_texture_handle_buffer,
+			ground_texture_handles.size() * sizeof(GLuint64),
+			ground_texture_handles.data(),
+			GL_DYNAMIC_STORAGE_BIT
+		);
+		glCreateBuffers(1, &ground_exists_buffer);
+		glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
 
-        // Cliff
-        glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &cliff_texture_array);
-        glTextureStorage3D(cliff_texture_array, log2(cliff_texture_size) + 1, GL_RGBA8, cliff_texture_size, cliff_texture_size, cliff_textures.size());
-        glTextureParameteri(cliff_texture_array, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
-        int sub = 0;
-        for (const auto& i : cliff_textures) {
-            glTextureSubImage3D(cliff_texture_array, 0, 0, 0, sub, i->width, i->height, 1, i->channels == 4 ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, i->data.data());
-            sub += 1;
-        }
-        glGenerateTextureMipmap(cliff_texture_array);
+		// Cliff
+		glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &cliff_texture_array);
+		glTextureStorage3D(
+			cliff_texture_array,
+			log2(cliff_texture_size) + 1,
+			GL_RGBA8,
+			cliff_texture_size,
+			cliff_texture_size,
+			cliff_textures.size()
+		);
+		glTextureParameteri(cliff_texture_array, GL_TEXTURE_MIN_FILTER, GL_LINEAR_MIPMAP_LINEAR);
+		int sub = 0;
+		for (const auto& i : cliff_textures) {
+			glTextureSubImage3D(
+				cliff_texture_array,
+				0,
+				0,
+				0,
+				sub,
+				i->width,
+				i->height,
+				1,
+				i->channels == 4 ? GL_RGBA : GL_RGB,
+				GL_UNSIGNED_BYTE,
+				i->data.data()
+			);
+			sub += 1;
+		}
+		glGenerateTextureMipmap(cliff_texture_array);
 
-        // Water
-        glCreateBuffers(1, &water_height_buffer);
-        glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &water_exists_buffer);
-        glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		// Water
+		glCreateBuffers(1, &water_height_buffer);
+		glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &water_exists_buffer);
+		glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
 
-        // Water textures
-        glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &water_texture_array);
-        glTextureStorage3D(water_texture_array, std::log(128) + 1, GL_RGBA8, 128, 128, water_textures_nr);
-        glTextureParameteri(water_texture_array, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        glTextureParameteri(water_texture_array, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+		// Water textures
+		glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &water_texture_array);
+		glTextureStorage3D(water_texture_array, std::log(128) + 1, GL_RGBA8, 128, 128, water_textures_nr);
+		glTextureParameteri(water_texture_array, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		glTextureParameteri(water_texture_array, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
-        const std::string_view file_name = water_slk.data<std::string_view>("texfile", tileset + "Sha"s);
-        for (int i = 0; i < water_textures_nr; i++) {
-	        // Hack to force loading of SD water textures till I implement a water shader
-        	const auto hd = hierarchy.hd;
-        	hierarchy.hd = false;
-        	const auto texture = resource_manager.load<Texture>(std::format("{}{:02}", file_name, i));
-        	hierarchy.hd = hd;
+		const std::string_view file_name = water_slk.data<std::string_view>("texfile", tileset + "Sha"s);
+		for (int i = 0; i < water_textures_nr; i++) {
+			// Hack to force loading of SD water textures till I implement a water shader
+			const auto hd = hierarchy.hd;
+			hierarchy.hd = false;
+			const auto texture = resource_manager.load<Texture>(std::format("{}{:02}", file_name, i));
+			hierarchy.hd = hd;
 
-            if (texture->width != 128 || texture->height != 128) {
-                std::cout << "Odd water texture size detected of " << texture->width << " wide and " << texture->height << " high\n";
-            }
-            glTextureSubImage3D(water_texture_array, 0, 0, 0, i, texture->width, texture->height, 1, texture->channels == 4 ? GL_RGBA : GL_RGB, GL_UNSIGNED_BYTE, texture->data.data());
-        }
-        glGenerateTextureMipmap(water_texture_array);
+			if (texture->width != 128 || texture->height != 128) {
+				std::cout << "Odd water texture size detected of " << texture->width << " wide and " << texture->height << " high\n";
+			}
+			glTextureSubImage3D(
+				water_texture_array,
+				0,
+				0,
+				0,
+				i,
+				texture->width,
+				texture->height,
+				1,
+				texture->channels == 4 ? GL_RGBA : GL_RGB,
+				GL_UNSIGNED_BYTE,
+				texture->data.data()
+			);
+		}
+		glGenerateTextureMipmap(water_texture_array);
 
-        ground_shader = resource_manager.load<Shader>({ "data/shaders/terrain.vert", "data/shaders/terrain.frag" });
-        cliff_shader = resource_manager.load<Shader>({ "data/shaders/cliff.vert", "data/shaders/cliff.frag" });
-        water_shader = resource_manager.load<Shader>({ "data/shaders/water.vert", "data/shaders/water.frag" });
+		ground_shader = resource_manager.load<Shader>({"data/shaders/terrain.vert", "data/shaders/terrain.frag"});
+		cliff_shader = resource_manager.load<Shader>({"data/shaders/cliff.vert", "data/shaders/cliff.frag"});
+		water_shader = resource_manager.load<Shader>({"data/shaders/water.vert", "data/shaders/water.frag"});
 
-        collision_shape = new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
-        collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
-        collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)); // Bullet centers the collision mesh automatically, we need to decenter it
-        collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
-        physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
+		collision_shape =
+			new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
+		collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
+		collision_body->getWorldTransform().setOrigin(
+			btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)
+		); // Bullet centers the collision mesh automatically, we need to decenter it
+		collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
+		physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
 
-        update_ground_textures({ 0, 0, width - 1, height - 1 });
-        update_ground_heights({ 0, 0, width - 1, height - 1 });
-        update_cliff_meshes({ 0, 0, width - 1, height - 1 });
-        update_water({ 0, 0, width - 1, height - 1 });
+		update_ground_textures({0, 0, width - 1, height - 1});
+		update_ground_heights({0, 0, width - 1, height - 1});
+		update_cliff_meshes({0, 0, width - 1, height - 1});
+		update_water({0, 0, width - 1, height - 1});
 
-        emit minimap_changed(minimap_image());
-    }
+		emit minimap_changed(minimap_image());
+	}
 
-    void save() const {
-        BinaryWriter writer;
-        writer.write_string("W3E!");
-        writer.write(write_version);
-        writer.write(tileset);
-        writer.write(1);
-        writer.write<uint32_t>(tileset_ids.size());
-        writer.write_vector(tileset_ids);
-        writer.write<uint32_t>(cliffset_ids.size());
-        writer.write_vector(cliffset_ids);
-        writer.write(width);
-        writer.write(height);
-        writer.write(offset);
+	void save() const {
+		BinaryWriter writer;
+		writer.write_string("W3E!");
+		writer.write(write_version);
+		writer.write(tileset);
+		writer.write(1);
+		writer.write<uint32_t>(tileset_ids.size());
+		writer.write_vector(tileset_ids);
+		writer.write<uint32_t>(cliffset_ids.size());
+		writer.write_vector(cliffset_ids);
+		writer.write(width);
+		writer.write(height);
+		writer.write(offset);
 
-        for (int j = 0; j < height; j++) {
-            for (int i = 0; i < width; i++) {
-                const Corner& corner = corners[i][j];
+		for (int j = 0; j < height; j++) {
+			for (int i = 0; i < width; i++) {
+				const Corner& corner = corners[i][j];
 
-                writer.write<uint16_t>(corner.height * 512.f + 8192.f);
+				writer.write<uint16_t>(corner.height * 512.f + 8192.f);
 
-                uint16_t water_and_edge = corner.water_height * 512.f + 8192.f;
-                water_and_edge += corner.map_edge << 14;
-                writer.write(water_and_edge);
+				uint16_t water_and_edge = corner.water_height * 512.f + 8192.f;
+				water_and_edge += corner.map_edge << 14;
+				writer.write(water_and_edge);
 
-                uint16_t texture_and_flags = corner.ground_texture;
-                texture_and_flags |= corner.ramp << 6;
+				uint16_t texture_and_flags = corner.ground_texture;
+				texture_and_flags |= corner.ramp << 6;
 
-                texture_and_flags |= corner.blight << 7;
-                texture_and_flags |= corner.water << 8;
-                texture_and_flags |= corner.boundary << 9;
-                writer.write(texture_and_flags);
+				texture_and_flags |= corner.blight << 7;
+				texture_and_flags |= corner.water << 8;
+				texture_and_flags |= corner.boundary << 9;
+				writer.write(texture_and_flags);
 
-                uint8_t variation = corner.ground_variation;
-                variation += corner.cliff_variation << 5;
-                writer.write(variation);
+				uint8_t variation = corner.ground_variation;
+				variation += corner.cliff_variation << 5;
+				writer.write(variation);
 
-                uint8_t misc = corner.cliff_texture << 4;
-                misc += corner.layer_height;
-                writer.write(misc);
-            }
-        }
+				uint8_t misc = corner.cliff_texture << 4;
+				misc += corner.layer_height;
+				writer.write(misc);
+			}
+		}
 
-        hierarchy.map_file_write("war3map.w3e", writer.buffer);
-    }
+		hierarchy.map_file_write("war3map.w3e", writer.buffer);
+	}
 
-    void render_ground(bool render_pathing, bool render_lighting, glm::vec3 light_direction, Brush* brush, PathingMap& pathing_map) const {
-        // Render tiles
-        ground_shader->use();
+	void render_ground(bool render_pathing, bool render_lighting, glm::vec3 light_direction, Brush* brush, PathingMap& pathing_map) const {
+		// Render tiles
+		ground_shader->use();
 
-        glDisable(GL_BLEND);
-        glEnable(GL_CULL_FACE);
+		glDisable(GL_BLEND);
+		glEnable(GL_CULL_FACE);
 
-        glUniformMatrix4fv(1, 1, GL_FALSE, &camera.projection_view[0][0]);
-        glUniform1i(2, render_pathing);
-        glUniform1i(3, render_lighting);
-        glUniform3fv(4, 1, &light_direction.x);
-        glUniform2i(7, width, height);
+		glUniformMatrix4fv(1, 1, GL_FALSE, &camera.projection_view[0][0]);
+		glUniform1i(2, render_pathing);
+		glUniform1i(3, render_lighting);
+		glUniform3fv(4, 1, &light_direction.x);
+		glUniform2i(7, width, height);
 
-        if (brush) {
-            glUniform2fv(5, 1, &brush->get_position()[0]);
-        }
+		if (brush) {
+			glUniform2fv(5, 1, &brush->get_position()[0]);
+		}
 
-        glBindTextureUnit(17, pathing_map.texture_static);
-        glBindTextureUnit(18, pathing_map.texture_dynamic);
+		glBindTextureUnit(17, pathing_map.texture_static);
+		glBindTextureUnit(18, pathing_map.texture_dynamic);
 
-        glUniform1i(6, brush && brush->get_mode() != Brush::Mode::selection);
-        if (brush) {
-            glBindTextureUnit(19, brush->brush_texture);
-        }
+		glUniform1i(6, brush && brush->get_mode() != Brush::Mode::selection);
+		if (brush) {
+			glBindTextureUnit(19, brush->brush_texture);
+		}
 
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cliff_level_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, ground_height_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, ground_texture_data_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, ground_exists_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, ground_texture_handle_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cliff_level_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, ground_height_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, ground_texture_data_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 3, ground_exists_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 4, ground_texture_handle_buffer);
 
-        // Use gl_VertexID in the shader to determine square position
-        glDrawArraysInstanced(GL_TRIANGLES, 0, 6, (width - 1) * (height - 1));
+		// Use gl_VertexID in the shader to determine square position
+		glDrawArraysInstanced(GL_TRIANGLES, 0, 6, (width - 1) * (height - 1));
 
-        glEnable(GL_BLEND);
+		glEnable(GL_BLEND);
 
-        // Render cliffs
-        for (const auto& i : cliffs) {
-            const Corner& bottom_left = corners[i.x][i.y];
-            const Corner& bottom_right = corners[i.x + 1][i.y];
-            const Corner& top_left = corners[i.x][i.y + 1];
-            const Corner& top_right = corners[i.x + 1][i.y + 1];
+		// Render cliffs
+		for (const auto& i : cliffs) {
+			const Corner& bottom_left = corners[i.x][i.y];
+			const Corner& bottom_right = corners[i.x + 1][i.y];
+			const Corner& top_left = corners[i.x][i.y + 1];
+			const Corner& top_right = corners[i.x + 1][i.y + 1];
 
-            if (bottom_left.special_doodad) {
-                continue;
-            }
+			if (bottom_left.special_doodad) {
+				continue;
+			}
 
-            const float min = std::min({ bottom_left.layer_height,	bottom_right.layer_height,
-                                        top_left.layer_height,		top_right.layer_height });
+			const float min =
+				std::min({bottom_left.layer_height, bottom_right.layer_height, top_left.layer_height, top_right.layer_height});
 
-            cliff_meshes[i.z]->render_queue({ i.x, i.y, min - 2, bottom_left.cliff_texture });
-        }
+			cliff_meshes[i.z]->render_queue({i.x, i.y, min - 2, bottom_left.cliff_texture});
+		}
 
-        cliff_shader->use();
+		cliff_shader->use();
 
-        glUniformMatrix4fv(0, 1, GL_FALSE, &camera.projection_view[0][0]);
-        glUniform1i(1, render_pathing);
-        glUniform1i(2, render_lighting);
-        glUniform3fv(3, 1, &light_direction.x);
-        if (brush) {
-            glUniform2fv(4, 1, &brush->get_position()[0]);
-        }
-        glUniform1i(5, brush && brush->get_mode() != Brush::Mode::selection);
+		glUniformMatrix4fv(0, 1, GL_FALSE, &camera.projection_view[0][0]);
+		glUniform1i(1, render_pathing);
+		glUniform1i(2, render_lighting);
+		glUniform3fv(3, 1, &light_direction.x);
+		if (brush) {
+			glUniform2fv(4, 1, &brush->get_position()[0]);
+		}
+		glUniform1i(5, brush && brush->get_mode() != Brush::Mode::selection);
 
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ground_height_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, ground_height_buffer);
 
-        glBindTextureUnit(0, cliff_texture_array);
-        glBindTextureUnit(2, pathing_map.texture_static);
+		glBindTextureUnit(0, cliff_texture_array);
+		glBindTextureUnit(2, pathing_map.texture_static);
 
-        glUniform2i(7, width, height);
+		glUniform2i(7, width, height);
 
-        if (brush) {
-            glBindTextureUnit(3, brush->brush_texture);
-        }
-        for (const auto& i : cliff_meshes) {
-            i->render();
-        }
-    }
+		if (brush) {
+			glBindTextureUnit(3, brush->brush_texture);
+		}
+		for (const auto& i : cliff_meshes) {
+			i->render();
+		}
+	}
 
-    void render_water() const {
-        glEnable(GL_BLEND);
-        glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
-        glDepthMask(false);
+	void render_water() const {
+		glEnable(GL_BLEND);
+		glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
+		glDepthMask(false);
 
-        water_shader->use();
+		water_shader->use();
 
-        glUniformMatrix4fv(0, 1, GL_FALSE, &camera.projection_view[0][0]);
-        glUniform4fv(1, 1, &shallow_color_min[0]);
-        glUniform4fv(2, 1, &shallow_color_max[0]);
-        glUniform4fv(3, 1, &deep_color_min[0]);
-        glUniform4fv(4, 1, &deep_color_max[0]);
-        glUniform1f(5, water_offset);
-        glUniform1i(6, current_texture);
-        glUniform2i(7, width, height);
+		glUniformMatrix4fv(0, 1, GL_FALSE, &camera.projection_view[0][0]);
+		glUniform4fv(1, 1, &shallow_color_min[0]);
+		glUniform4fv(2, 1, &shallow_color_max[0]);
+		glUniform4fv(3, 1, &deep_color_min[0]);
+		glUniform4fv(4, 1, &deep_color_max[0]);
+		glUniform1f(5, water_offset);
+		glUniform1i(6, current_texture);
+		glUniform2i(7, width, height);
 
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cliff_level_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, water_height_buffer);
-        glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, water_exists_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 0, cliff_level_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 1, water_height_buffer);
+		glBindBufferBase(GL_SHADER_STORAGE_BUFFER, 2, water_exists_buffer);
 
-        glBindTextureUnit(0, water_texture_array);
+		glBindTextureUnit(0, water_texture_array);
 
-        // Use gl_VertexID in the shader to determine square position
-        glDrawArraysInstanced(GL_TRIANGLES, 0, 6, (width - 1) * (height - 1));
+		// Use gl_VertexID in the shader to determine square position
+		glDrawArraysInstanced(GL_TRIANGLES, 0, 6, (width - 1) * (height - 1));
 
-        glDepthMask(true);
-    }
+		glDepthMask(true);
+	}
 
-    void change_tileset(const std::vector<std::string>& new_tileset_ids, std::vector<int> new_to_old) {
-        tileset_ids = new_tileset_ids;
+	void change_tileset(const std::vector<std::string>& new_tileset_ids, std::vector<int> new_to_old) {
+		tileset_ids = new_tileset_ids;
 
-        // Blight
-        new_to_old.push_back(new_tileset_ids.size());
+		// Blight
+		new_to_old.push_back(new_tileset_ids.size());
 
-        // Map old ids to the new ids
-        for (auto& i : corners) {
-            for (auto& j : i) {
-                j.ground_texture = new_to_old[j.ground_texture];
-            }
-        }
+		// Map old ids to the new ids
+		for (auto& i : corners) {
+			for (auto& j : i) {
+				j.ground_texture = new_to_old[j.ground_texture];
+			}
+		}
 
-        // Reload tile textures
-        ground_textures.clear();	// ToDo Clear them after loading new ones?
-        ground_texture_to_id.clear();
+		// Reload tile textures
+		ground_textures.clear(); // ToDo Clear them after loading new ones?
+		ground_texture_to_id.clear();
 		ground_texture_handles.clear();
 
-        for (const auto& tile_id : tileset_ids) {
-            ground_textures.push_back(resource_manager.load<GroundTexture>(terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id) + (hierarchy.hd ? "_diffuse.dds" : ".dds")));
-            ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
-        	ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
-        }
-        blight_texture = static_cast<int>(ground_textures.size());
-        ground_texture_to_id.emplace("blight", blight_texture);
-        ground_textures.push_back(resource_manager.load<GroundTexture>(world_edit_data.data("TileSets", std::string(1, tileset), 1) + (hierarchy.hd ? "_diffuse.dds" : ".dds")));
+		for (const auto& tile_id : tileset_ids) {
+			ground_textures.push_back(resource_manager.load<GroundTexture>(
+				terrain_slk.data("dir", tile_id) + "/" + terrain_slk.data("file", tile_id) + (hierarchy.hd ? "_diffuse.dds" : ".dds")
+			));
+			ground_texture_to_id.emplace(tile_id, static_cast<int>(ground_textures.size() - 1));
+			ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
+		}
+		blight_texture = static_cast<int>(ground_textures.size());
+		ground_texture_to_id.emplace("blight", blight_texture);
+		ground_textures.push_back(resource_manager.load<GroundTexture>(
+			world_edit_data.data("TileSets", std::string(1, tileset), 1) + (hierarchy.hd ? "_diffuse.dds" : ".dds")
+		));
 		ground_texture_handles.push_back(ground_textures.back()->bindless_handle);
 
-		glNamedBufferStorage(ground_texture_handle_buffer, ground_texture_handles.size() * sizeof(GLuint64), ground_texture_handles.data(), GL_DYNAMIC_STORAGE_BIT);
-
-        cliff_to_ground_texture.clear();
-        for (const auto& cliff_id : cliffset_ids) {
-            cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data("groundtile", cliff_id)]);
-        }
-
-        update_ground_textures({ 0, 0, width, height });
-    }
-
-    /// The texture of the tilepoint which is influenced by its surroundings. nearby cliff/ramp > blight > regular texture
-    [[nodiscard]] int real_tile_texture(const int x, const int y) const {
-        for (int i = -1; i < 1; i++) {
-            for (int j = -1; j < 1; j++) {
-                if (x + i >= 0 && x + i < width && y + j >= 0 && y + j < height) {
-                    if (corners[x + i][y + j].cliff) {
-                        if (x + i < width - 1 && y + j < height - 1) {
-                            const Corner& bottom_left = corners[x + i][y + j];
-                            const Corner& bottom_right = corners[x + i + 1][y + j];
-                            const Corner& top_left = corners[x + i][y + j + 1];
-                            const Corner& top_right = corners[x + i + 1][y + j + 1];
-
-                            if (bottom_left.ramp && top_left.ramp && bottom_right.ramp && top_right.ramp && !bottom_left.romp && !bottom_right.romp && !top_left.romp && !top_right.romp) {
-                                goto out_of_loop;
-                            }
-                        }
-                    }
-
-                    if (corners[x + i][y + j].romp || corners[x + i][y + j].cliff) {
-                        int texture = corners[x + i][y + j].cliff_texture;
-                        // Number 15 seems to be something
-                        if (texture == 15) {
-                            texture -= 14;
-                        }
-
-                        return cliff_to_ground_texture[texture];
-                    }
-                }
-            }
-        }
-    out_of_loop:
-
-        if (corners[x][y].blight) {
-            return blight_texture;
-        }
-
-        return corners[x][y].ground_texture;
-    }
-
-    /// The subtexture of a groundtexture to use.
-    int get_tile_variation(const int ground_texture, const int variation) const {
-        if (ground_textures[ground_texture]->extended) {
-            if (variation <= 15) {
-                return 16 + variation;
-            } else if (variation == 16) {
-                return 15;
-            } else {
-                return 0;
-            }
-        } else {
-            if (variation == 0) {
-                return 0;
-            } else {
-                return 15;
-            }
-        }
-    }
-
-    /// The 4 ground textures of the tilepoint. The first 16 bits are which texture array to use and the next 16 bits are which subtexture to use
-    glm::uvec4 get_texture_variations(const int x, const int y) const {
-        const int bottom_left = real_tile_texture(x, y);
-        const int bottom_right = real_tile_texture(x + 1, y);
-        const int top_left = real_tile_texture(x, y + 1);
-        const int top_right = real_tile_texture(x + 1, y + 1);
-
-        std::set<int> set({ bottom_left, bottom_right, top_left, top_right });
-        glm::uvec4 tiles(0xFFFF); // 0xFFFF is a transparent black pixel in the fragment shader
-        int component = 1;
-
-        tiles.x = *set.begin() + (get_tile_variation(*set.begin(), corners[x][y].ground_variation) << 16);
-        set.erase(set.begin());
-
-        std::bitset<4> index;
-        for (auto&& texture : set) {
-            index[0] = bottom_right == texture;
-            index[1] = bottom_left == texture;
-            index[2] = top_right == texture;
-            index[3] = top_left == texture;
-
-            tiles[component++] = texture + (index.to_ulong() << 16);
-        }
-        return tiles;
-    }
-
-    /// Returns the height at x,y by bilinear interpolation
-    /// Set water_too to true to also take the water height into account
-    float interpolated_height(float x, float y, bool water_too) const {
-        x = std::clamp(x, 0.f, width - 1.01f);
-        y = std::clamp(y, 0.f, height - 1.01f);
-
-
-        float p1 = corners[x][y].final_ground_height();
-        float p2 = corners[std::ceil(x)][y].final_ground_height();
-
-        float p3 = corners[x][std::ceil(y)].final_ground_height();
-        float p4 = corners[std::ceil(x)][std::ceil(y)].final_ground_height();
-
-        if (water_too && corners[x][y].water) {
-            p1 = std::max(p1, corners[x][y].final_water_height(water_offset));
-        }
-
-        if (water_too && corners[std::ceil(x)][y].water) {
-            p2 = std::max(p2, corners[std::ceil(x)][y].final_water_height(water_offset));
-        }
-
-        if (water_too && corners[x][std::ceil(y)].water) {
-            p3 = std::max(p3, corners[x][std::ceil(y)].final_water_height(water_offset));
-        }
-
-        if (water_too && corners[std::ceil(x)][std::ceil(y)].water) {
-            p4 = std::max(p4, corners[std::ceil(x)][std::ceil(y)].final_water_height(water_offset));
-        }
-
-        float xx = glm::mix(p1, p2, x - floor(x));
-        float yy = glm::mix(p3, p4, x - floor(x));
-        return glm::mix(xx, yy, y - floor(y));
-    }
-
-    // Returns the y gradient in radians
-    float gradient_y(float x, float y) const {
-        x = std::clamp(x, 0.f, width - 1.01f);
-        y = std::clamp(y, 0.f, height - 1.01f);
-
-        float bottom_left = corners[x][y].final_ground_height(); // Is it bottom left?
-        float bottom_right = corners[x + 1.f][y].final_ground_height();
-        float top_left = corners[x][y + 1.f].final_ground_height();
-        float top_right = corners[x + 1.f][y + 1.f].final_ground_height();
-
-        float bottom = glm::mix(bottom_left, bottom_right, x - glm::floor(x));
-        float top = glm::mix(top_left, top_right, x - glm::floor(x));
-
-        return std::atan(bottom - top);
-    }
-
-    bool is_corner_ramp_entrance(int x, int y) {
-        if (x == width || y == height) {
-            return false;
-        }
-
-        Corner& bottom_left = corners[x][y];
-        Corner& bottom_right = corners[x + 1][y];
-        Corner& top_left = corners[x][y + 1];
-        Corner& top_right = corners[x + 1][y + 1];
-
-        return bottom_left.ramp && top_left.ramp && bottom_right.ramp && top_right.ramp && !(bottom_left.layer_height == top_right.layer_height && top_left.layer_height == bottom_right.layer_height);
-    }
-
-    /// Constructs a minimap image with tile, cliff, and water colors. Other objects such as doodads will not be added here
-    Texture minimap_image() {
-        Texture new_minimap_image;
-
-        new_minimap_image.width = width;
-        new_minimap_image.height = height;
-        new_minimap_image.channels = 4;
-        new_minimap_image.data.resize(width * height * 4);
-
-        for (int j = 0; j < height; j++) {
-            for (int i = 0; i < width; i++) {
-                glm::vec4 color;
-
-                if (corners[i][j].cliff || (i > 0 && corners[i - 1][j].cliff) || (j > 0 && corners[i][j - 1].cliff) || (i > 0 && j > 0 && corners[i - 1][j - 1].cliff)) {
-                    color = glm::vec4(128.f, 128.f, 128.f, 255.f);
-                } else {
-                    color = ground_textures[real_tile_texture(i, j)]->minimap_color;
-                }
-
-                if (corners[i][j].water && corners[i][j].final_water_height(water_offset) > corners[i][j].final_ground_height()) {
-                    if (corners[i][j].final_water_height(water_offset) - corners[i][j].final_ground_height() > 0.5f) {
-                        color *= 0.5625f;
-                        color += glm::vec4(0, 0, 80, 112);
-                    } else {
-                        color *= 0.75f;
-                        color += glm::vec4(0, 0, 48, 64);
-                    }
-                }
-
-                int index = (height - 1 - j) * (width * 4) + i * 4;
-                new_minimap_image.data[index + 0] = color.r;
-                new_minimap_image.data[index + 1] = color.g;
-                new_minimap_image.data[index + 2] = color.b;
-                new_minimap_image.data[index + 3] = color.a;
-
-            }
-        }
-
-        return new_minimap_image;
-    }
-
-    void upload_ground_heights() const {
-        glNamedBufferSubData(ground_height_buffer, 0, ground_heights.size() * sizeof(float), ground_heights.data());
-    }
-
-    void upload_corner_heights() const {
-        glNamedBufferSubData(cliff_level_buffer, 0, final_ground_heights.size() * sizeof(float), final_ground_heights.data());
-    }
-
-    void upload_ground_texture() const {
-        glNamedBufferSubData(ground_texture_data_buffer, 0, ground_texture_list.size() * sizeof(glm::uvec4), ground_texture_list.data());
-    }
-
-    void upload_ground_exists() const {
-        glNamedBufferSubData(ground_exists_buffer, 0, ground_exists_data.size() * sizeof(uint32_t), ground_exists_data.data());
-    }
-
-    void upload_water_exists() const {
-        glNamedBufferSubData(water_exists_buffer, 0, water_exists_data.size() * sizeof(uint32_t), water_exists_data.data());
-    }
-
-    void upload_water_heights() const {
-        glNamedBufferSubData(water_height_buffer, 0, water_heights.size() * sizeof(float), water_heights.data());
-    }
-
-    void update_ground_heights(const QRect& area) {
-        for (int j = area.y(); j < area.y() + area.height(); j++) {
-            for (int i = area.x(); i < area.x() + area.width(); i++) {
-                ground_heights[j * width + i] = corners[i][j].height; // todo 15.998???
-
-                float ramp_height = 0.f;
-                // Check if in one of the configurations the bottom_left is a ramp
-                for (int x_offset = -1; x_offset <= 0; x_offset++) {
-                    for (int y_offset = -1; y_offset <= 0; y_offset++) {
-                        if (i + x_offset >= 0 && i + x_offset < width - 1 && j + y_offset >= 0 && j + y_offset < height - 1) {
-                            const Corner& bottom_left = corners[i + x_offset][j + y_offset];
-                            const Corner& bottom_right = corners[i + 1 + x_offset][j + y_offset];
-                            const Corner& top_left = corners[i + x_offset][j + 1 + y_offset];
-                            const Corner& top_right = corners[i + 1 + x_offset][j + 1 + y_offset];
-
-                            const int base = std::min({ bottom_left.layer_height, bottom_right.layer_height, top_left.layer_height, top_right.layer_height });
-                            if (corners[i][j].layer_height != base) {
-                                continue;
-                            }
-
-                            if (is_corner_ramp_entrance(i + x_offset, j + y_offset)) {
-                                ramp_height = 0.5f;
-                                goto exit_loop;
-                            }
-                        }
-                    }
-                }
-            exit_loop:
-
-                final_ground_heights[j * width + i] = corners[i][j].final_ground_height() + ramp_height;
-            }
-        }
-
-        upload_ground_heights();
-        upload_corner_heights();
-    }
-
-    /// Updates the ground texture variation information and uploads it to the GPU
-    void update_ground_textures(const QRect& area) {
-        const QRect update_area = area.adjusted(-1, -1, 1, 1).intersected({ 0, 0, width - 1, height - 1 });
-
-        for (int j = update_area.top(); j <= update_area.bottom(); j++) {
-            for (int i = update_area.left(); i <= update_area.right(); i++) {
-                ground_texture_list[j * (width - 1) + i] = get_texture_variations(i, j);
-            }
-        }
-
-        upload_ground_texture();
-    }
-
-    void update_ground_exists(const QRect& area) {
-        QRect update_area = area.adjusted(-1, -1, 1, 1).intersected({ 0, 0, width - 1, height - 1 });
-
-        for (int j = update_area.top(); j <= update_area.bottom(); j++) {
-            for (int i = update_area.left(); i <= update_area.right(); i++) {
-                ground_exists_data[j * (width - 1) + i] = !(((corners[i][j].cliff || corners[i][j].romp) && !is_corner_ramp_entrance(i, j)) || corners[i][j].special_doodad);
-            }
-        }
-
-        upload_ground_exists();
-    }
-
-    /// Updates and uploads the water data for the GPU
-    void update_water(const QRect& area) {
-        for (int i = area.x(); i < area.x() + area.width(); i++) {
-            for (int j = area.y(); j < area.y() + area.height(); j++) {
-                water_exists_data[j * width + i] = corners[i][j].water;
-                water_heights[j * width + i] = corners[i][j].water_height;
-            }
-        }
-        upload_water_exists();
-        upload_water_heights();
-    }
-
-    /// ToDo clean
-    /// Function is a bit of a mess
-    /// Updates the cliff and ramp meshes for an area
-    void update_cliff_meshes(const QRect& area) {
-        // Remove all existing cliff meshes in area
-        for (size_t i = cliffs.size(); i-- > 0;) {
-            glm::ivec3& pos = cliffs[i];
-            if (area.contains(pos.x, pos.y)) {
-                cliffs.erase(cliffs.begin() + i);
-            }
-        }
-
-        for (int i = area.x(); i < area.right(); i++) {
-            for (int j = area.y(); j < area.bottom(); j++) {
-                corners[i][j].romp = false;
-            }
-        }
-
-        QRect ramp_area = area.adjusted(-2, -2, 2, 2).intersected({ 0, 0, width, height });
-
-        // Add new cliff meshes
-        for (int i = ramp_area.x(); i < ramp_area.right(); i++) {
-            for (int j = ramp_area.y(); j < ramp_area.bottom(); j++) {
-                Corner& bottom_left = corners[i][j];
-                Corner& bottom_right = corners[i + 1][j];
-                Corner& top_left = corners[i][j + 1];
-                Corner& top_right = corners[i + 1][j + 1];
-
-                // Vertical ramps
-                if (j < height - 2) {
-                    const Corner& top_top_left = corners[i][j + 2];
-                    const Corner& top_top_right = corners[i + 1][j + 2];
-                    const int ae = std::min(bottom_left.layer_height, top_top_left.layer_height);
-                    const int cf = std::min(bottom_right.layer_height, top_top_right.layer_height);
-
-                    if (top_left.layer_height == ae && top_right.layer_height == cf) {
-                        int base = std::min(ae, cf);
-                        if (bottom_left.ramp == top_left.ramp
-                            && bottom_left.ramp == top_top_left.ramp
-                            && bottom_right.ramp == top_right.ramp
-                            && bottom_right.ramp == top_top_right.ramp
-                            && bottom_left.ramp != bottom_right.ramp) {
-
-                            std::string file_name = ""s
-                                + char((top_top_left.ramp ? 'L' : 'A') + (top_top_left.layer_height - base) * (top_top_left.ramp ? -4 : 1))
-                                + char((top_top_right.ramp ? 'L' : 'A') + (top_top_right.layer_height - base) * (top_top_right.ramp ? -4 : 1))
-                                + char((bottom_right.ramp ? 'L' : 'A') + (bottom_right.layer_height - base) * (bottom_right.ramp ? -4 : 1))
-                                + char((bottom_left.ramp ? 'L' : 'A') + (bottom_left.layer_height - base) * (bottom_left.ramp ? -4 : 1));
-
-                            file_name = "doodads/terrain/clifftrans/clifftrans" + file_name + "0.mdx";
-                            if (hierarchy.file_exists(file_name)) {
-                                if (!path_to_cliff.contains(file_name)) {
-                                    cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
-                                    path_to_cliff.emplace(file_name, static_cast<int>(cliff_meshes.size()) - 1);
-                                }
-
-                                cliffs.emplace_back(i, j, path_to_cliff[file_name]);
-                                bottom_left.romp = true;
-                                top_left.romp = true;
-
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                // Horizontal ramps
-                if (i < width - 2) {
-                    const Corner& bottom_right_right = corners[i + 2][j];
-                    const Corner& top_right_right = corners[i + 2][j + 1];
-                    const int ae = std::min(bottom_left.layer_height, bottom_right_right.layer_height);
-                    const int bf = std::min(top_left.layer_height, top_right_right.layer_height);
-
-                    if (bottom_right.layer_height == ae && top_right.layer_height == bf) {
-                        int base = std::min(ae, bf);
-                        if (bottom_left.ramp == bottom_right.ramp
-                            && bottom_left.ramp == bottom_right_right.ramp
-                            && top_left.ramp == top_right.ramp
-                            && top_left.ramp == top_right_right.ramp
-                            && bottom_left.ramp != top_left.ramp) {
-
-                            std::string file_name = ""s
-                                + char((top_left.ramp ? 'L' : 'A') + (top_left.layer_height - base) * (top_left.ramp ? -4 : 1))
-                                + char((top_right_right.ramp ? 'L' : 'A') + (top_right_right.layer_height - base) * (top_right_right.ramp ? -4 : 1))
-                                + char((bottom_right_right.ramp ? 'L' : 'A') + (bottom_right_right.layer_height - base) * (bottom_right_right.ramp ? -4 : 1))
-                                + char((bottom_left.ramp ? 'L' : 'A') + (bottom_left.layer_height - base) * (bottom_left.ramp ? -4 : 1));
-
-                            file_name = "doodads/terrain/clifftrans/clifftrans" + file_name + "0.mdx";
-                            if (hierarchy.file_exists(file_name)) {
-                                if (!path_to_cliff.contains(file_name)) {
-                                    cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
-                                    path_to_cliff.emplace(file_name, static_cast<int>(cliff_meshes.size()) - 1);
-                                }
-
-                                cliffs.emplace_back(i, j, path_to_cliff[file_name]);
-                                bottom_left.romp = true;
-                                bottom_right.romp = true;
-
-                                continue;
-                            }
-                        }
-                    }
-                }
-
-                if (!bottom_left.cliff || bottom_left.romp) {
-                    continue;
-                }
-
-                if (is_corner_ramp_entrance(i, j)) {
-                    continue;
-                }
-
-                const int base = std::min({bottom_left.layer_height, bottom_right.layer_height, top_left.layer_height, top_right.layer_height});
-
-                // Cliff model path
-                std::string file_name = ""s
-                    + char('A' + top_left.layer_height - base)
-                    + char('A' + top_right.layer_height - base)
-                    + char('A' + bottom_right.layer_height - base)
-                    + char('A' + bottom_left.layer_height - base);
-
-                if (file_name == "AAAA") {
-                    continue;
-                }
-
-                // Clamp to within max variations
-                file_name += std::to_string(std::clamp(bottom_left.cliff_variation, 0, cliff_variations[file_name]));
-
-                cliffs.emplace_back(i, j, path_to_cliff[file_name]);
-            }
-        }
-
-        update_ground_exists(ramp_area);
-    }
-
-    void resize(size_t new_width, size_t new_height) {
-        //glDeleteTextures(1, &ground_height);
-        //glDeleteTextures(1, &ground_texture_data);
-        //glDeleteTextures(1, &ground_exists);
-
-        //glDeleteTextures(1, &water_exists);
-        //glDeleteTextures(1, &water_height);
-
-        //width = new_width;
-        //height = new_height;
-
-        //auto t = corners[0][0];
-        //corners.clear();
-        //corners.resize(width, std::vector<Corner>(height, t));
-
-        //ground_heights.resize(width * height);
-        //ground_corner_heights.resize(width * height);
-        //ground_texture_list.resize((width - 1) * (height - 1));
-        //ground_exists_data.resize(width * height);
-
-        //water_heights.resize(width * height);
-        //water_exists_data.resize(width * height);
-
-        //for (int i = 0; i < width; i++) {
-        //	for (int j = 0; j < height; j++) {
-        //		ground_corner_heights[j * width + i] = corners[i][j].final_ground_height();
-        //		water_exists_data[j * width + i] = corners[i][j].water;
-        //		ground_heights[j * width + i] = corners[i][j].height;
-        //		water_heights[j * width + i] = corners[i][j].water_height;
-        //	}
-        //}
-
-        //for (int i = 0; i < width - 1; i++) {
-        //	for (int j = 0; j < height - 1; j++) {
-        //		Corner& bottom_left = corners[i][j];
-        //		Corner& bottom_right = corners[i + 1][j];
-        //		Corner& top_left = corners[i][j + 1];
-        //		Corner& top_right = corners[i + 1][j + 1];
-
-        //		bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height || bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
-        //	}
-        //}
-
-        //glCreateTextures(GL_TEXTURE_2D, 1, &ground_height);
-        //glTextureStorage2D(ground_height, 1, GL_R16F, width, height);
-        //glTextureSubImage2D(ground_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_heights.data());
-        //glTextureParameteri(ground_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        //glTextureParameteri(ground_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-        //glCreateTextures(GL_TEXTURE_2D, 1, &ground_corner_height);
-        //glTextureStorage2D(ground_corner_height, 1, GL_R16F, width, height);
-        //glTextureSubImage2D(ground_corner_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_corner_heights.data());
-        //glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-        //glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-        //glCreateTextures(GL_TEXTURE_2D, 1, &ground_texture_data);
-        //glTextureStorage2D(ground_texture_data, 1, GL_RGBA16UI, width - 1, height - 1);
-        //glTextureParameteri(ground_texture_data, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-        //glTextureParameteri(ground_texture_data, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-        //glCreateTextures(GL_TEXTURE_2D, 1, &ground_exists);
-        //glTextureStorage2D(ground_exists, 1, GL_R8, width, height);
-
-        //// Water
-        //glCreateTextures(GL_TEXTURE_2D, 1, &water_height);
-        //glTextureStorage2D(water_height, 1, GL_R16F, width, height);
-        //glTextureSubImage2D(water_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, water_heights.data());
-
-        //glCreateTextures(GL_TEXTURE_2D, 1, &water_exists);
-        //glTextureStorage2D(water_exists, 1, GL_R8, width, height);
-        //glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-        //glTextureSubImage2D(water_exists, 0, 0, 0, width, height, GL_RED, GL_UNSIGNED_BYTE, water_exists_data.data());
-        //glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-
-        //update_cliff_meshes({ 0, 0, width - 1, height - 1 });
-        //update_ground_textures({ 0, 0, width - 1, height - 1 });
-        //update_ground_heights({ 0, 0, width - 1, height - 1 });
-
-        //map->physics.dynamicsWorld->removeRigidBody(collision_body);
-        //delete collision_body;
-        //delete collision_shape;
-
-        //collision_shape = new btHeightfieldTerrainShape(width, height, ground_corner_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
-        //if (collision_shape == nullptr) {
-        //	std::cout << "Error creating Bullet collision shape\n";
-        //}
-        //collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
-        //collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)); // Bullet centers the collision mesh automatically, we need to decenter it and place it under the player
-        //collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
-        //map->physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
-    }
-
-    /// Computes the terrain pathing flags for the target cell. 
-    /// Takes cliffs, blight, water, terrain textures and boundaries into account
-    uint8_t get_terrain_pathing(size_t i, size_t j) {        
-        // Use floor division to correctly map pathing cells to corners
-        int corner_x = static_cast<int>(std::floor(i / 4.0));
-        int corner_y = static_cast<int>(std::floor(j / 4.0));
-        const Corner& bottom_left = corners[corner_x][corner_y];
-
-        // take terrain texture into account (from the closest corner)
-        int x = static_cast<int>(std::round(i / 4.0));
-        int y = static_cast<int>(std::round(j / 4.0));
-        const Corner& closest_corner = corners[x][y];
-        uint8_t mask = pathing_options[tileset_ids[closest_corner.ground_texture]].mask();
-
-        // cliffs are unbuildable and unwalkable
-        if (bottom_left.cliff) {
-            mask |= PathingMap::unbuildable | PathingMap::unwalkable;
-        } 
-        
-        // take blight into account
-        if (closest_corner.blight) {
-            mask |= 0b00100000;
-        }
-
-        // take water into account
-        if (closest_corner.water) {
-            // apply water mask
-            mask |= 0b01000000;
-
-            if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height() + 0.40) {
-                // deep water is unwalkable and unbuildable
-                mask |= PathingMap::unbuildable | PathingMap::unwalkable;
-            } else if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height()) {
-                // shallow water is unbuildable
-                mask |= PathingMap::unbuildable;
-            }
-        }
-
-        // boundaries and map edges are unwalkable, unflyable and unbuildable¸
-        // NOTE: game handles corners/boundaries differently
-        // if the bottom-left corner is a boundary, then the entire 4x4 cell is considered a boundary
-        if (bottom_left.map_edge || bottom_left.boundary) {
-            mask |= PathingMap::unbuildable | PathingMap::unflyable | PathingMap::unwalkable;
-        }
-
-        return mask;
-    }
-
-    /// Updates the map_edge flags (shadows on the edges of the map) 
-    void set_unplayable_boundaries(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
-        // places "shadows" on the edges of the map
-        for (size_t i = 0; i < width; i++) {
-            for (size_t j = 0; j < height; j++) {
-                bool is_boundary = false;
-                
-                // check all bounduaries
-                if (i < unplayable_left) {
-                    is_boundary = true;
-                }
-                else if (i >= width - unplayable_right) {
-                    is_boundary = true;
-                }
-                else if (j < unplayable_bottom) {
-                    is_boundary = true;
-                }
-                else if (j >= height - unplayable_top) {
-                    is_boundary = true;
-                }
-                
-                corners[i][j].map_edge = is_boundary;
-            }
-        }
-
-        emit minimap_changed(minimap_image());
-    }
-
-    /// Resizes the terrain by expanding/shrinking it from all four sides
-    void resize(int delta_left, int delta_right, int delta_top, int delta_bottom, Physics& physics) {
-        const int new_width = width + delta_left + delta_right;
-        const int new_height = height + delta_top + delta_bottom;
-
-        // width/height must be at least 33
-        if (new_width < 33 || new_height < 33) {
-            return;
-        }
-
-        // maximum map size supported by wc3 is 481 x 481
-        if (new_width > 481 || new_height > 481) {
-            return;
-        }
-
-        // sanity check, (size - 1) must be multiple of 32
-        if (new_width % 32 != 1  || new_height % 32 != 1) {
-            return;
-        }
-
-        // create and setup
-        std::vector<std::vector<Corner>> new_corners = resize_corners(delta_left, delta_right, delta_top, delta_bottom);
-
-        // update terrain object
-        width = new_width;
-        height = new_height;
-        corners = new_corners;
-        offset.x -= delta_left * 128;
-        offset.y -= delta_bottom * 128;
-
-        re_render(physics);
-
-        emit minimap_changed(minimap_image());
-    }
-
-    void update_minimap() {
-        emit minimap_changed(minimap_image());
-    }
-
-    static int get_random_variation() {
-        std::random_device rd;
-        std::mt19937 e2(rd());
-        std::uniform_int_distribution<> dist(0, 570);
-
-        int nr = dist(e2) - 1;
-
-        for (auto&&[variation, chance] : variation_chances) {
-            if (nr < chance) {
-                return variation;
-            }
-            nr -= chance;
-        }
-        assert("Didn't hit the list of tile variations");
-        return 0;
-    }
-
-private:
-    Corner create_default_corner() const {
-        // creates a corner with default values, used when resize destroys the original terrain
-        Corner corner;
-
-        corner.map_edge = false;
-
-        corner.ramp = false;
-        corner.blight = false;
-        corner.water = false;
-        corner.boundary = false;
-        corner.cliff = false;
-        corner.special_doodad = false;
-
-        corner.layer_height = 2;
-        corner.cliff_texture = 15;
-        corner.cliff_variation = 0;
-
-        corner.height = 0;
-        corner.water_height = 0;
-
-        corner.ground_texture = 0;
-
-        return corner;
-    }
-
-    std::vector<std::vector<Corner>> resize_corners(int delta_left, int delta_right, int delta_top, int delta_bottom) const {
-        const int new_width = width + delta_left + delta_right;
-        const int new_height = height + delta_top + delta_bottom;
-
-        // initialise new corner vector
-        std::vector<std::vector<Corner>> new_corners(new_width, std::vector<Corner>(new_height));
-
-        // check if all old corners would be removed
-        int old_width_remaining = (int)width + std::min(0, delta_left) + std::min(0, delta_right);
-        int old_height_remaining = (int)height + std::min(0, delta_bottom) + std::min(0, delta_top);
-        if (old_width_remaining <= 0 || old_height_remaining <= 0) {
-            // all old corners deleted, fill with default
-            Corner default_corner = create_default_corner();
-            for (size_t i = 0; i < new_width; i++) {
-                for (size_t j = 0; j < new_height; j++) {
-                    // apply random tile variation and fix map_edge flag
-                    default_corner.ground_variation = get_random_variation();
-                    default_corner.map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
-                    new_corners[i][j] = default_corner;
-                }
-            }
-            return new_corners;
-        }
-
-        // fill the new corners by mapping from old corners
-        for (size_t i = 0; i < new_width; i++) {
-            for (size_t j = 0; j < new_height; j++) {
-                // map new position to old position
-                int old_i = (int)i - delta_left;
-                int old_j = (int)j - delta_bottom;
-                
-                // check if this is an old corner (before clamping)
-                bool is_old_corner = (old_i >= 0 && old_i < (int)width && old_j >= 0 && old_j < (int)height);
-                
-                // clamp to valid old range
-                old_i = std::clamp(old_i, 0, (int)width - 1);
-                old_j = std::clamp(old_j, 0, (int)height - 1);
-                
-                new_corners[i][j] = corners[old_i][old_j];
-                
-                // fix map_edge flag for all corners
-                //new_corners[i][j].map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
-                
-                // apply random variations and fix special_doodad for NEW corners
-                if (!is_old_corner) {
-                    new_corners[i][j].special_doodad = false;
-                    new_corners[i][j].ground_variation = get_random_variation();
-                }
-            }
-        }
-
-        return new_corners;
-    }
-
-    void re_render(Physics& physics) {
-        // clear old buffers
-        glDeleteBuffers(1, &ground_height_buffer);
-        glDeleteBuffers(1, &cliff_level_buffer);
-        glDeleteBuffers(1, &water_height_buffer);
-        glDeleteBuffers(1, &ground_texture_data_buffer);
-        glDeleteBuffers(1, &ground_exists_buffer);
-        glDeleteBuffers(1, &water_exists_buffer);
-
-        // clear all cliffs (this prevents out of bounds error when shrinking terrain)
-        cliffs.clear();
-
-        // clear romp flags on all corners
-        for (int i = 0; i < width; i++) {
-            for (int j = 0; j < height; j++) {
-                corners[i][j].romp = false;
-            }
-        }
-
-        // resize GPU buffer vectors
-        ground_heights.resize(width * height);
-        final_ground_heights.resize(width * height);
-        ground_texture_list.resize((width - 1) * (height - 1));
-        ground_exists_data.resize(width * height);
-        water_heights.resize(width * height);
-        water_exists_data.resize(width * height);
-
-        // determine cliff flags for all corners
-        for (int i = 0; i < width - 1; i++) {
-            for (int j = 0; j < height - 1; j++) {
-                Corner& bottom_left = corners[i][j];
-                Corner& bottom_right = corners[i + 1][j];
-                Corner& top_left = corners[i][j + 1];
-                Corner& top_right = corners[i + 1][j + 1];
-
-                bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
-                    || bottom_left.layer_height != top_left.layer_height
-                    || bottom_left.layer_height != top_right.layer_height;
-            }
-        }
-
-        // recreate GPU buffers with new size
-        glCreateBuffers(1, &ground_height_buffer);
-        glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &cliff_level_buffer);
-        glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &ground_texture_data_buffer);
-        glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &ground_exists_buffer);
-        glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &water_height_buffer);
-        glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-        glCreateBuffers(1, &water_exists_buffer);
-        glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
-
-        // update everything else
-        update_ground_heights({ 0, 0, width, height });
-        update_ground_textures({ 0, 0, width - 1, height - 1 });
-        update_cliff_meshes({ 0, 0, width - 1, height - 1 });
-        update_water({ 0, 0, width, height });
-
-        // update physics collision shapeated)
-        physics.dynamicsWorld->removeRigidBody(collision_body);
-        delete collision_body;
-        delete collision_shape;
-
-        collision_shape = new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
-        collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
-        collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f));
-        collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
-        physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
-    }
-
-signals:
+		glNamedBufferStorage(
+			ground_texture_handle_buffer,
+			ground_texture_handles.size() * sizeof(GLuint64),
+			ground_texture_handles.data(),
+			GL_DYNAMIC_STORAGE_BIT
+		);
+
+		cliff_to_ground_texture.clear();
+		for (const auto& cliff_id : cliffset_ids) {
+			cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data("groundtile", cliff_id)]);
+		}
+
+		update_ground_textures({0, 0, width, height});
+	}
+
+	/// The texture of the tilepoint which is influenced by its surroundings. nearby cliff/ramp > blight > regular texture
+	[[nodiscard]]
+	int real_tile_texture(const int x, const int y) const {
+		for (int i = -1; i < 1; i++) {
+			for (int j = -1; j < 1; j++) {
+				if (x + i >= 0 && x + i < width && y + j >= 0 && y + j < height) {
+					if (corners[x + i][y + j].cliff) {
+						if (x + i < width - 1 && y + j < height - 1) {
+							const Corner& bottom_left = corners[x + i][y + j];
+							const Corner& bottom_right = corners[x + i + 1][y + j];
+							const Corner& top_left = corners[x + i][y + j + 1];
+							const Corner& top_right = corners[x + i + 1][y + j + 1];
+
+							if (bottom_left.ramp && top_left.ramp && bottom_right.ramp && top_right.ramp && !bottom_left.romp
+								&& !bottom_right.romp && !top_left.romp && !top_right.romp) {
+								goto out_of_loop;
+							}
+						}
+					}
+
+					if (corners[x + i][y + j].romp || corners[x + i][y + j].cliff) {
+						int texture = corners[x + i][y + j].cliff_texture;
+						// Number 15 seems to be something
+						if (texture == 15) {
+							texture -= 14;
+						}
+
+						return cliff_to_ground_texture[texture];
+					}
+				}
+			}
+		}
+	out_of_loop:
+
+		if (corners[x][y].blight) {
+			return blight_texture;
+		}
+
+		return corners[x][y].ground_texture;
+	}
+
+	/// The subtexture of a groundtexture to use.
+	int get_tile_variation(const int ground_texture, const int variation) const {
+		if (ground_textures[ground_texture]->extended) {
+			if (variation <= 15) {
+				return 16 + variation;
+			} else if (variation == 16) {
+				return 15;
+			} else {
+				return 0;
+			}
+		} else {
+			if (variation == 0) {
+				return 0;
+			} else {
+				return 15;
+			}
+		}
+	}
+
+	/// The 4 ground textures of the tilepoint. The first 16 bits are which texture array to use and the next 16 bits are which subtexture to use
+	glm::uvec4 get_texture_variations(const int x, const int y) const {
+		const int bottom_left = real_tile_texture(x, y);
+		const int bottom_right = real_tile_texture(x + 1, y);
+		const int top_left = real_tile_texture(x, y + 1);
+		const int top_right = real_tile_texture(x + 1, y + 1);
+
+		std::set<int> set({bottom_left, bottom_right, top_left, top_right});
+		glm::uvec4 tiles(0xFFFF); // 0xFFFF is a transparent black pixel in the fragment shader
+		int component = 1;
+
+		tiles.x = *set.begin() + (get_tile_variation(*set.begin(), corners[x][y].ground_variation) << 16);
+		set.erase(set.begin());
+
+		std::bitset<4> index;
+		for (auto&& texture : set) {
+			index[0] = bottom_right == texture;
+			index[1] = bottom_left == texture;
+			index[2] = top_right == texture;
+			index[3] = top_left == texture;
+
+			tiles[component++] = texture + (index.to_ulong() << 16);
+		}
+		return tiles;
+	}
+
+	/// Returns the height at x,y by bilinear interpolation
+	/// Set water_too to true to also take the water height into account
+	float interpolated_height(float x, float y, bool water_too) const {
+		x = std::clamp(x, 0.f, width - 1.01f);
+		y = std::clamp(y, 0.f, height - 1.01f);
+
+		float p1 = corners[x][y].final_ground_height();
+		float p2 = corners[std::ceil(x)][y].final_ground_height();
+
+		float p3 = corners[x][std::ceil(y)].final_ground_height();
+		float p4 = corners[std::ceil(x)][std::ceil(y)].final_ground_height();
+
+		if (water_too && corners[x][y].water) {
+			p1 = std::max(p1, corners[x][y].final_water_height(water_offset));
+		}
+
+		if (water_too && corners[std::ceil(x)][y].water) {
+			p2 = std::max(p2, corners[std::ceil(x)][y].final_water_height(water_offset));
+		}
+
+		if (water_too && corners[x][std::ceil(y)].water) {
+			p3 = std::max(p3, corners[x][std::ceil(y)].final_water_height(water_offset));
+		}
+
+		if (water_too && corners[std::ceil(x)][std::ceil(y)].water) {
+			p4 = std::max(p4, corners[std::ceil(x)][std::ceil(y)].final_water_height(water_offset));
+		}
+
+		float xx = glm::mix(p1, p2, x - floor(x));
+		float yy = glm::mix(p3, p4, x - floor(x));
+		return glm::mix(xx, yy, y - floor(y));
+	}
+
+	// Returns the y gradient in radians
+	float gradient_y(float x, float y) const {
+		x = std::clamp(x, 0.f, width - 1.01f);
+		y = std::clamp(y, 0.f, height - 1.01f);
+
+		float bottom_left = corners[x][y].final_ground_height(); // Is it bottom left?
+		float bottom_right = corners[x + 1.f][y].final_ground_height();
+		float top_left = corners[x][y + 1.f].final_ground_height();
+		float top_right = corners[x + 1.f][y + 1.f].final_ground_height();
+
+		float bottom = glm::mix(bottom_left, bottom_right, x - glm::floor(x));
+		float top = glm::mix(top_left, top_right, x - glm::floor(x));
+
+		return std::atan(bottom - top);
+	}
+
+	bool is_corner_ramp_entrance(int x, int y) {
+		if (x == width || y == height) {
+			return false;
+		}
+
+		Corner& bottom_left = corners[x][y];
+		Corner& bottom_right = corners[x + 1][y];
+		Corner& top_left = corners[x][y + 1];
+		Corner& top_right = corners[x + 1][y + 1];
+
+		return bottom_left.ramp && top_left.ramp && bottom_right.ramp && top_right.ramp
+			&& !(bottom_left.layer_height == top_right.layer_height && top_left.layer_height == bottom_right.layer_height);
+	}
+
+	/// Constructs a minimap image with tile, cliff, and water colors. Other objects such as doodads will not be added here
+	Texture minimap_image() {
+		Texture new_minimap_image;
+
+		new_minimap_image.width = width;
+		new_minimap_image.height = height;
+		new_minimap_image.channels = 4;
+		new_minimap_image.data.resize(width * height * 4);
+
+		for (int j = 0; j < height; j++) {
+			for (int i = 0; i < width; i++) {
+				glm::vec4 color;
+
+				if (corners[i][j].cliff || (i > 0 && corners[i - 1][j].cliff) || (j > 0 && corners[i][j - 1].cliff)
+					|| (i > 0 && j > 0 && corners[i - 1][j - 1].cliff)) {
+					color = glm::vec4(128.f, 128.f, 128.f, 255.f);
+				} else {
+					color = ground_textures[real_tile_texture(i, j)]->minimap_color;
+				}
+
+				if (corners[i][j].water && corners[i][j].final_water_height(water_offset) > corners[i][j].final_ground_height()) {
+					if (corners[i][j].final_water_height(water_offset) - corners[i][j].final_ground_height() > 0.5f) {
+						color *= 0.5625f;
+						color += glm::vec4(0, 0, 80, 112);
+					} else {
+						color *= 0.75f;
+						color += glm::vec4(0, 0, 48, 64);
+					}
+				}
+
+				int index = (height - 1 - j) * (width * 4) + i * 4;
+				new_minimap_image.data[index + 0] = color.r;
+				new_minimap_image.data[index + 1] = color.g;
+				new_minimap_image.data[index + 2] = color.b;
+				new_minimap_image.data[index + 3] = color.a;
+			}
+		}
+
+		return new_minimap_image;
+	}
+
+	void upload_ground_heights() const {
+		glNamedBufferSubData(ground_height_buffer, 0, ground_heights.size() * sizeof(float), ground_heights.data());
+	}
+
+	void upload_corner_heights() const {
+		glNamedBufferSubData(cliff_level_buffer, 0, final_ground_heights.size() * sizeof(float), final_ground_heights.data());
+	}
+
+	void upload_ground_texture() const {
+		glNamedBufferSubData(ground_texture_data_buffer, 0, ground_texture_list.size() * sizeof(glm::uvec4), ground_texture_list.data());
+	}
+
+	void upload_ground_exists() const {
+		glNamedBufferSubData(ground_exists_buffer, 0, ground_exists_data.size() * sizeof(uint32_t), ground_exists_data.data());
+	}
+
+	void upload_water_exists() const {
+		glNamedBufferSubData(water_exists_buffer, 0, water_exists_data.size() * sizeof(uint32_t), water_exists_data.data());
+	}
+
+	void upload_water_heights() const {
+		glNamedBufferSubData(water_height_buffer, 0, water_heights.size() * sizeof(float), water_heights.data());
+	}
+
+	void update_ground_heights(const QRect& area) {
+		for (int j = area.y(); j < area.y() + area.height(); j++) {
+			for (int i = area.x(); i < area.x() + area.width(); i++) {
+				ground_heights[j * width + i] = corners[i][j].height; // todo 15.998???
+
+				float ramp_height = 0.f;
+				// Check if in one of the configurations the bottom_left is a ramp
+				for (int x_offset = -1; x_offset <= 0; x_offset++) {
+					for (int y_offset = -1; y_offset <= 0; y_offset++) {
+						if (i + x_offset >= 0 && i + x_offset < width - 1 && j + y_offset >= 0 && j + y_offset < height - 1) {
+							const Corner& bottom_left = corners[i + x_offset][j + y_offset];
+							const Corner& bottom_right = corners[i + 1 + x_offset][j + y_offset];
+							const Corner& top_left = corners[i + x_offset][j + 1 + y_offset];
+							const Corner& top_right = corners[i + 1 + x_offset][j + 1 + y_offset];
+
+							const int base = std::min(
+								{bottom_left.layer_height, bottom_right.layer_height, top_left.layer_height, top_right.layer_height}
+							);
+							if (corners[i][j].layer_height != base) {
+								continue;
+							}
+
+							if (is_corner_ramp_entrance(i + x_offset, j + y_offset)) {
+								ramp_height = 0.5f;
+								goto exit_loop;
+							}
+						}
+					}
+				}
+			exit_loop:
+
+				final_ground_heights[j * width + i] = corners[i][j].final_ground_height() + ramp_height;
+			}
+		}
+
+		upload_ground_heights();
+		upload_corner_heights();
+	}
+
+	/// Updates the ground texture variation information and uploads it to the GPU
+	void update_ground_textures(const QRect& area) {
+		const QRect update_area = area.adjusted(-1, -1, 1, 1).intersected({0, 0, width - 1, height - 1});
+
+		for (int j = update_area.top(); j <= update_area.bottom(); j++) {
+			for (int i = update_area.left(); i <= update_area.right(); i++) {
+				ground_texture_list[j * (width - 1) + i] = get_texture_variations(i, j);
+			}
+		}
+
+		upload_ground_texture();
+	}
+
+	void update_ground_exists(const QRect& area) {
+		QRect update_area = area.adjusted(-1, -1, 1, 1).intersected({0, 0, width - 1, height - 1});
+
+		for (int j = update_area.top(); j <= update_area.bottom(); j++) {
+			for (int i = update_area.left(); i <= update_area.right(); i++) {
+				ground_exists_data[j * (width - 1) + i] =
+					!(((corners[i][j].cliff || corners[i][j].romp) && !is_corner_ramp_entrance(i, j)) || corners[i][j].special_doodad);
+			}
+		}
+
+		upload_ground_exists();
+	}
+
+	/// Updates and uploads the water data for the GPU
+	void update_water(const QRect& area) {
+		for (int i = area.x(); i < area.x() + area.width(); i++) {
+			for (int j = area.y(); j < area.y() + area.height(); j++) {
+				water_exists_data[j * width + i] = corners[i][j].water;
+				water_heights[j * width + i] = corners[i][j].water_height;
+			}
+		}
+		upload_water_exists();
+		upload_water_heights();
+	}
+
+	/// ToDo clean
+	/// Function is a bit of a mess
+	/// Updates the cliff and ramp meshes for an area
+	void update_cliff_meshes(const QRect& area) {
+		// Remove all existing cliff meshes in area
+		for (size_t i = cliffs.size(); i-- > 0;) {
+			glm::ivec3& pos = cliffs[i];
+			if (area.contains(pos.x, pos.y)) {
+				cliffs.erase(cliffs.begin() + i);
+			}
+		}
+
+		for (int i = area.x(); i < area.right(); i++) {
+			for (int j = area.y(); j < area.bottom(); j++) {
+				corners[i][j].romp = false;
+			}
+		}
+
+		QRect ramp_area = area.adjusted(-2, -2, 2, 2).intersected({0, 0, width, height});
+
+		// Add new cliff meshes
+		for (int i = ramp_area.x(); i < ramp_area.right(); i++) {
+			for (int j = ramp_area.y(); j < ramp_area.bottom(); j++) {
+				Corner& bottom_left = corners[i][j];
+				Corner& bottom_right = corners[i + 1][j];
+				Corner& top_left = corners[i][j + 1];
+				Corner& top_right = corners[i + 1][j + 1];
+
+				// Vertical ramps
+				if (j < height - 2) {
+					const Corner& top_top_left = corners[i][j + 2];
+					const Corner& top_top_right = corners[i + 1][j + 2];
+					const int ae = std::min(bottom_left.layer_height, top_top_left.layer_height);
+					const int cf = std::min(bottom_right.layer_height, top_top_right.layer_height);
+
+					if (top_left.layer_height == ae && top_right.layer_height == cf) {
+						int base = std::min(ae, cf);
+						if (bottom_left.ramp == top_left.ramp && bottom_left.ramp == top_top_left.ramp
+							&& bottom_right.ramp == top_right.ramp && bottom_right.ramp == top_top_right.ramp
+							&& bottom_left.ramp != bottom_right.ramp) {
+							std::string file_name = ""s
+								+ char((top_top_left.ramp ? 'L' : 'A') + (top_top_left.layer_height - base) * (top_top_left.ramp ? -4 : 1))
+								+ char((top_top_right.ramp ? 'L' : 'A')
+									   + (top_top_right.layer_height - base) * (top_top_right.ramp ? -4 : 1))
+								+ char((bottom_right.ramp ? 'L' : 'A') + (bottom_right.layer_height - base) * (bottom_right.ramp ? -4 : 1))
+								+ char((bottom_left.ramp ? 'L' : 'A') + (bottom_left.layer_height - base) * (bottom_left.ramp ? -4 : 1));
+
+							file_name = "doodads/terrain/clifftrans/clifftrans" + file_name + "0.mdx";
+							if (hierarchy.file_exists(file_name)) {
+								if (!path_to_cliff.contains(file_name)) {
+									cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
+									path_to_cliff.emplace(file_name, static_cast<int>(cliff_meshes.size()) - 1);
+								}
+
+								cliffs.emplace_back(i, j, path_to_cliff[file_name]);
+								bottom_left.romp = true;
+								top_left.romp = true;
+
+								continue;
+							}
+						}
+					}
+				}
+
+				// Horizontal ramps
+				if (i < width - 2) {
+					const Corner& bottom_right_right = corners[i + 2][j];
+					const Corner& top_right_right = corners[i + 2][j + 1];
+					const int ae = std::min(bottom_left.layer_height, bottom_right_right.layer_height);
+					const int bf = std::min(top_left.layer_height, top_right_right.layer_height);
+
+					if (bottom_right.layer_height == ae && top_right.layer_height == bf) {
+						int base = std::min(ae, bf);
+						if (bottom_left.ramp == bottom_right.ramp && bottom_left.ramp == bottom_right_right.ramp
+							&& top_left.ramp == top_right.ramp && top_left.ramp == top_right_right.ramp
+							&& bottom_left.ramp != top_left.ramp) {
+							std::string file_name = ""s
+								+ char((top_left.ramp ? 'L' : 'A') + (top_left.layer_height - base) * (top_left.ramp ? -4 : 1))
+								+ char((top_right_right.ramp ? 'L' : 'A')
+									   + (top_right_right.layer_height - base) * (top_right_right.ramp ? -4 : 1))
+								+ char((bottom_right_right.ramp ? 'L' : 'A')
+									   + (bottom_right_right.layer_height - base) * (bottom_right_right.ramp ? -4 : 1))
+								+ char((bottom_left.ramp ? 'L' : 'A') + (bottom_left.layer_height - base) * (bottom_left.ramp ? -4 : 1));
+
+							file_name = "doodads/terrain/clifftrans/clifftrans" + file_name + "0.mdx";
+							if (hierarchy.file_exists(file_name)) {
+								if (!path_to_cliff.contains(file_name)) {
+									cliff_meshes.push_back(resource_manager.load<CliffMesh>(file_name));
+									path_to_cliff.emplace(file_name, static_cast<int>(cliff_meshes.size()) - 1);
+								}
+
+								cliffs.emplace_back(i, j, path_to_cliff[file_name]);
+								bottom_left.romp = true;
+								bottom_right.romp = true;
+
+								continue;
+							}
+						}
+					}
+				}
+
+				if (!bottom_left.cliff || bottom_left.romp) {
+					continue;
+				}
+
+				if (is_corner_ramp_entrance(i, j)) {
+					continue;
+				}
+
+				const int base =
+					std::min({bottom_left.layer_height, bottom_right.layer_height, top_left.layer_height, top_right.layer_height});
+
+				// Cliff model path
+				std::string file_name = ""s + char('A' + top_left.layer_height - base) + char('A' + top_right.layer_height - base)
+					+ char('A' + bottom_right.layer_height - base) + char('A' + bottom_left.layer_height - base);
+
+				if (file_name == "AAAA") {
+					continue;
+				}
+
+				// Clamp to within max variations
+				file_name += std::to_string(std::clamp(bottom_left.cliff_variation, 0, cliff_variations[file_name]));
+
+				cliffs.emplace_back(i, j, path_to_cliff[file_name]);
+			}
+		}
+
+		update_ground_exists(ramp_area);
+	}
+
+	void resize(size_t new_width, size_t new_height) {
+		//glDeleteTextures(1, &ground_height);
+		//glDeleteTextures(1, &ground_texture_data);
+		//glDeleteTextures(1, &ground_exists);
+
+		//glDeleteTextures(1, &water_exists);
+		//glDeleteTextures(1, &water_height);
+
+		//width = new_width;
+		//height = new_height;
+
+		//auto t = corners[0][0];
+		//corners.clear();
+		//corners.resize(width, std::vector<Corner>(height, t));
+
+		//ground_heights.resize(width * height);
+		//ground_corner_heights.resize(width * height);
+		//ground_texture_list.resize((width - 1) * (height - 1));
+		//ground_exists_data.resize(width * height);
+
+		//water_heights.resize(width * height);
+		//water_exists_data.resize(width * height);
+
+		//for (int i = 0; i < width; i++) {
+		//	for (int j = 0; j < height; j++) {
+		//		ground_corner_heights[j * width + i] = corners[i][j].final_ground_height();
+		//		water_exists_data[j * width + i] = corners[i][j].water;
+		//		ground_heights[j * width + i] = corners[i][j].height;
+		//		water_heights[j * width + i] = corners[i][j].water_height;
+		//	}
+		//}
+
+		//for (int i = 0; i < width - 1; i++) {
+		//	for (int j = 0; j < height - 1; j++) {
+		//		Corner& bottom_left = corners[i][j];
+		//		Corner& bottom_right = corners[i + 1][j];
+		//		Corner& top_left = corners[i][j + 1];
+		//		Corner& top_right = corners[i + 1][j + 1];
+
+		//		bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height || bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
+		//	}
+		//}
+
+		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_height);
+		//glTextureStorage2D(ground_height, 1, GL_R16F, width, height);
+		//glTextureSubImage2D(ground_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_heights.data());
+		//glTextureParameteri(ground_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		//glTextureParameteri(ground_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_corner_height);
+		//glTextureStorage2D(ground_corner_height, 1, GL_R16F, width, height);
+		//glTextureSubImage2D(ground_corner_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_corner_heights.data());
+		//glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+		//glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
+
+		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_texture_data);
+		//glTextureStorage2D(ground_texture_data, 1, GL_RGBA16UI, width - 1, height - 1);
+		//glTextureParameteri(ground_texture_data, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
+		//glTextureParameteri(ground_texture_data, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
+
+		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_exists);
+		//glTextureStorage2D(ground_exists, 1, GL_R8, width, height);
+
+		//// Water
+		//glCreateTextures(GL_TEXTURE_2D, 1, &water_height);
+		//glTextureStorage2D(water_height, 1, GL_R16F, width, height);
+		//glTextureSubImage2D(water_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, water_heights.data());
+
+		//glCreateTextures(GL_TEXTURE_2D, 1, &water_exists);
+		//glTextureStorage2D(water_exists, 1, GL_R8, width, height);
+		//glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
+		//glTextureSubImage2D(water_exists, 0, 0, 0, width, height, GL_RED, GL_UNSIGNED_BYTE, water_exists_data.data());
+		//glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
+
+		//update_cliff_meshes({ 0, 0, width - 1, height - 1 });
+		//update_ground_textures({ 0, 0, width - 1, height - 1 });
+		//update_ground_heights({ 0, 0, width - 1, height - 1 });
+
+		//map->physics.dynamicsWorld->removeRigidBody(collision_body);
+		//delete collision_body;
+		//delete collision_shape;
+
+		//collision_shape = new btHeightfieldTerrainShape(width, height, ground_corner_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
+		//if (collision_shape == nullptr) {
+		//	std::cout << "Error creating Bullet collision shape\n";
+		//}
+		//collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
+		//collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)); // Bullet centers the collision mesh automatically, we need to decenter it and place it under the player
+		//collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
+		//map->physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
+	}
+
+	/// Computes the terrain pathing flags for the target cell.
+	/// Takes cliffs, blight, water, terrain textures and boundaries into account
+	uint8_t get_terrain_pathing(size_t i, size_t j) {
+		// Use floor division to correctly map pathing cells to corners
+		int corner_x = static_cast<int>(std::floor(i / 4.0));
+		int corner_y = static_cast<int>(std::floor(j / 4.0));
+		const Corner& bottom_left = corners[corner_x][corner_y];
+
+		// take terrain texture into account (from the closest corner)
+		int x = static_cast<int>(std::round(i / 4.0));
+		int y = static_cast<int>(std::round(j / 4.0));
+		const Corner& closest_corner = corners[x][y];
+		uint8_t mask = pathing_options[tileset_ids[closest_corner.ground_texture]].mask();
+
+		// cliffs are unbuildable and unwalkable
+		if (bottom_left.cliff) {
+			mask |= PathingMap::unbuildable | PathingMap::unwalkable;
+		}
+
+		// take blight into account
+		if (closest_corner.blight) {
+			mask |= 0b00100000;
+		}
+
+		// take water into account
+		if (closest_corner.water) {
+			// apply water mask
+			mask |= 0b01000000;
+
+			if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height() + 0.40) {
+				// deep water is unwalkable and unbuildable
+				mask |= PathingMap::unbuildable | PathingMap::unwalkable;
+			} else if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height()) {
+				// shallow water is unbuildable
+				mask |= PathingMap::unbuildable;
+			}
+		}
+
+		// boundaries and map edges are unwalkable, unflyable and unbuildable¸
+		// NOTE: game handles corners/boundaries differently
+		// if the bottom-left corner is a boundary, then the entire 4x4 cell is considered a boundary
+		if (bottom_left.map_edge || bottom_left.boundary) {
+			mask |= PathingMap::unbuildable | PathingMap::unflyable | PathingMap::unwalkable;
+		}
+
+		return mask;
+	}
+
+	/// Updates the map_edge flags (shadows on the edges of the map)
+	void set_unplayable_boundaries(int unplayable_left, int unplayable_right, int unplayable_top, int unplayable_bottom) {
+		// places "shadows" on the edges of the map
+		for (size_t i = 0; i < width; i++) {
+			for (size_t j = 0; j < height; j++) {
+				bool is_boundary = false;
+
+				// check all bounduaries
+				if (i < unplayable_left) {
+					is_boundary = true;
+				} else if (i >= width - unplayable_right) {
+					is_boundary = true;
+				} else if (j < unplayable_bottom) {
+					is_boundary = true;
+				} else if (j >= height - unplayable_top) {
+					is_boundary = true;
+				}
+
+				corners[i][j].map_edge = is_boundary;
+			}
+		}
+
+		emit minimap_changed(minimap_image());
+	}
+
+	/// Resizes the terrain by expanding/shrinking it from all four sides
+	void resize(int delta_left, int delta_right, int delta_top, int delta_bottom, Physics& physics) {
+		const int new_width = width + delta_left + delta_right;
+		const int new_height = height + delta_top + delta_bottom;
+
+		// width/height must be at least 33
+		if (new_width < 33 || new_height < 33) {
+			return;
+		}
+
+		// maximum map size supported by wc3 is 481 x 481
+		if (new_width > 481 || new_height > 481) {
+			return;
+		}
+
+		// sanity check, (size - 1) must be multiple of 32
+		if (new_width % 32 != 1 || new_height % 32 != 1) {
+			return;
+		}
+
+		// create and setup
+		std::vector<std::vector<Corner>> new_corners = resize_corners(delta_left, delta_right, delta_top, delta_bottom);
+
+		// update terrain object
+		width = new_width;
+		height = new_height;
+		corners = new_corners;
+		offset.x -= delta_left * 128;
+		offset.y -= delta_bottom * 128;
+
+		re_render(physics);
+
+		emit minimap_changed(minimap_image());
+	}
+
+	void update_minimap() {
+		emit minimap_changed(minimap_image());
+	}
+
+	static int get_random_variation() {
+		std::random_device rd;
+		std::mt19937 e2(rd());
+		std::uniform_int_distribution<> dist(0, 570);
+
+		int nr = dist(e2) - 1;
+
+		for (auto&& [variation, chance] : variation_chances) {
+			if (nr < chance) {
+				return variation;
+			}
+			nr -= chance;
+		}
+		assert("Didn't hit the list of tile variations");
+		return 0;
+	}
+
+  private:
+	Corner create_default_corner() const {
+		// creates a corner with default values, used when resize destroys the original terrain
+		Corner corner;
+
+		corner.map_edge = false;
+
+		corner.ramp = false;
+		corner.blight = false;
+		corner.water = false;
+		corner.boundary = false;
+		corner.cliff = false;
+		corner.special_doodad = false;
+
+		corner.layer_height = 2;
+		corner.cliff_texture = 15;
+		corner.cliff_variation = 0;
+
+		corner.height = 0;
+		corner.water_height = 0;
+
+		corner.ground_texture = 0;
+
+		return corner;
+	}
+
+	std::vector<std::vector<Corner>> resize_corners(int delta_left, int delta_right, int delta_top, int delta_bottom) const {
+		const int new_width = width + delta_left + delta_right;
+		const int new_height = height + delta_top + delta_bottom;
+
+		// initialise new corner vector
+		std::vector<std::vector<Corner>> new_corners(new_width, std::vector<Corner>(new_height));
+
+		// check if all old corners would be removed
+		int old_width_remaining = (int)width + std::min(0, delta_left) + std::min(0, delta_right);
+		int old_height_remaining = (int)height + std::min(0, delta_bottom) + std::min(0, delta_top);
+		if (old_width_remaining <= 0 || old_height_remaining <= 0) {
+			// all old corners deleted, fill with default
+			Corner default_corner = create_default_corner();
+			for (size_t i = 0; i < new_width; i++) {
+				for (size_t j = 0; j < new_height; j++) {
+					// apply random tile variation and fix map_edge flag
+					default_corner.ground_variation = get_random_variation();
+					default_corner.map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
+					new_corners[i][j] = default_corner;
+				}
+			}
+			return new_corners;
+		}
+
+		// fill the new corners by mapping from old corners
+		for (size_t i = 0; i < new_width; i++) {
+			for (size_t j = 0; j < new_height; j++) {
+				// map new position to old position
+				int old_i = (int)i - delta_left;
+				int old_j = (int)j - delta_bottom;
+
+				// check if this is an old corner (before clamping)
+				bool is_old_corner = (old_i >= 0 && old_i < (int)width && old_j >= 0 && old_j < (int)height);
+
+				// clamp to valid old range
+				old_i = std::clamp(old_i, 0, (int)width - 1);
+				old_j = std::clamp(old_j, 0, (int)height - 1);
+
+				new_corners[i][j] = corners[old_i][old_j];
+
+				// fix map_edge flag for all corners
+				//new_corners[i][j].map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
+
+				// apply random variations and fix special_doodad for NEW corners
+				if (!is_old_corner) {
+					new_corners[i][j].special_doodad = false;
+					new_corners[i][j].ground_variation = get_random_variation();
+				}
+			}
+		}
+
+		return new_corners;
+	}
+
+	void re_render(Physics& physics) {
+		// clear old buffers
+		glDeleteBuffers(1, &ground_height_buffer);
+		glDeleteBuffers(1, &cliff_level_buffer);
+		glDeleteBuffers(1, &water_height_buffer);
+		glDeleteBuffers(1, &ground_texture_data_buffer);
+		glDeleteBuffers(1, &ground_exists_buffer);
+		glDeleteBuffers(1, &water_exists_buffer);
+
+		// clear all cliffs (this prevents out of bounds error when shrinking terrain)
+		cliffs.clear();
+
+		// clear romp flags on all corners
+		for (int i = 0; i < width; i++) {
+			for (int j = 0; j < height; j++) {
+				corners[i][j].romp = false;
+			}
+		}
+
+		// resize GPU buffer vectors
+		ground_heights.resize(width * height);
+		final_ground_heights.resize(width * height);
+		ground_texture_list.resize((width - 1) * (height - 1));
+		ground_exists_data.resize(width * height);
+		water_heights.resize(width * height);
+		water_exists_data.resize(width * height);
+
+		// determine cliff flags for all corners
+		for (int i = 0; i < width - 1; i++) {
+			for (int j = 0; j < height - 1; j++) {
+				Corner& bottom_left = corners[i][j];
+				Corner& bottom_right = corners[i + 1][j];
+				Corner& top_left = corners[i][j + 1];
+				Corner& top_right = corners[i + 1][j + 1];
+
+				bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
+					|| bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
+			}
+		}
+
+		// recreate GPU buffers with new size
+		glCreateBuffers(1, &ground_height_buffer);
+		glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &cliff_level_buffer);
+		glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &ground_texture_data_buffer);
+		glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &ground_exists_buffer);
+		glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &water_height_buffer);
+		glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		glCreateBuffers(1, &water_exists_buffer);
+		glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+
+		// update everything else
+		update_ground_heights({0, 0, width, height});
+		update_ground_textures({0, 0, width - 1, height - 1});
+		update_cliff_meshes({0, 0, width - 1, height - 1});
+		update_water({0, 0, width, height});
+
+		// update physics collision shapeated)
+		physics.dynamicsWorld->removeRigidBody(collision_body);
+		delete collision_body;
+		delete collision_shape;
+
+		collision_shape =
+			new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
+		collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
+		collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f));
+		collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
+		physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
+	}
+
+  signals:
 	void minimap_changed(Texture minimap);
 };
 

--- a/src/base/terrain.ixx
+++ b/src/base/terrain.ixx
@@ -32,53 +32,25 @@ import "btBulletDynamicsCommon.h";
 using namespace std::literals::string_literals;
 
 export struct Corner {
-	bool map_edge;
+	bool map_edge = false;
 
-	int ground_texture;
+	int ground_texture = 0;
 
-	float height;
-	float water_height;
-	bool ramp;
-	bool blight;
-	bool water;
-	bool boundary;
+	float height = 0.f;
+	float water_height = 0.f;
+	bool ramp = false;
+	bool blight = false;
+	bool water = false;
+	bool boundary = false;
 	bool cliff = false;
 	bool romp = false;
 	bool special_doodad = false;
 
-	int ground_variation;
-	int cliff_variation;
+	int ground_variation = 0;
+	int cliff_variation = 0;
 
-	int cliff_texture;
-	int layer_height;
-
-	float final_ground_height() const {
-		return height + layer_height - 2.0;
-	}
-
-	float final_water_height(const float water_offset) const {
-		return water_height + water_offset;
-	}
-};
-
-export struct TilePathingg {
-	bool unwalkable = false;
-	bool unflyable = false;
-	bool unbuildable = false;
-
-	uint8_t mask() const {
-		uint8_t mask = 0;
-		mask |= unwalkable ? 0b00000010 : 0;
-		mask |= unflyable ? 0b00000100 : 0;
-		mask |= unbuildable ? 0b00001000 : 0;
-		return mask;
-	}
-};
-
-export class Terrain: public QObject {
-	Q_OBJECT
-
-	static constexpr int write_version = 12;
+	int cliff_texture = 15;
+	int layer_height = 2;
 
 	// total sum 570
 	static constexpr std::tuple<int, int> variation_chances[18] = {
@@ -101,6 +73,52 @@ export class Terrain: public QObject {
 		{14, 4},
 		{15, 1}
 	};
+
+	float final_ground_height() const {
+		return height + layer_height - 2.0;
+	}
+
+	float final_water_height(const float water_offset) const {
+		return water_height + water_offset;
+	}
+
+	void set_random_variation() {
+		std::random_device rd;
+		std::mt19937 e2(rd());
+		std::uniform_int_distribution<> dist(0, 570);
+
+		int nr = dist(e2) - 1;
+
+		for (auto&& [variation, chance] : variation_chances) {
+			if (nr < chance) {
+				ground_variation = variation;
+				return;
+			}
+			nr -= chance;
+		}
+		assert("Didn't hit the list of tile variations");
+		ground_variation = 0;
+	}
+};
+
+export struct TilePathingg {
+	bool unwalkable = false;
+	bool unflyable = false;
+	bool unbuildable = false;
+
+	uint8_t mask() const {
+		uint8_t mask = 0;
+		mask |= unwalkable ? 0b00000010 : 0;
+		mask |= unflyable ? 0b00000100 : 0;
+		mask |= unbuildable ? 0b00001000 : 0;
+		return mask;
+	}
+};
+
+export class Terrain: public QObject {
+	Q_OBJECT
+
+	static constexpr int write_version = 12;
 
 	// Sequential versions for GPU uploading
 	std::vector<float> ground_heights;
@@ -274,17 +292,8 @@ export class Terrain: public QObject {
 
 	void create(const Physics& physics) {
 		// Determine if cliff
-		for (int i = 0; i < width - 1; i++) {
-			for (int j = 0; j < height - 1; j++) {
-				Corner& bottom_left = corners[i][j];
-				Corner& bottom_right = corners[i + 1][j];
-				Corner& top_left = corners[i][j + 1];
-				Corner& top_right = corners[i + 1][j + 1];
+		compute_cliff_flags();
 
-				bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
-					|| bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
-			}
-		}
 		// Done parsing
 
 		hierarchy.tileset = tileset;
@@ -368,21 +377,10 @@ export class Terrain: public QObject {
 			cliff_to_ground_texture.push_back(ground_texture_to_id[cliff_slk.data<std::string_view>("groundtile", cliff_id)]);
 		}
 
-		// prepare GPU buffers
-		ground_heights.resize(width * height);
-		final_ground_heights.resize(width * height);
-		ground_texture_list.resize((width - 1) * (height - 1));
-		ground_exists_data.resize(width * height);
-		water_heights.resize(width * height);
-		water_exists_data.resize(width * height);
+		// Prepare and create GPU buffers
+		setup_GPU_buffers();
 
-		// Ground
-		glCreateBuffers(1, &ground_height_buffer);
-		glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-		glCreateBuffers(1, &cliff_level_buffer);
-		glNamedBufferStorage(cliff_level_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-		glCreateBuffers(1, &ground_texture_data_buffer);
-		glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
+		// Ground texture handle buffer (only needed during initial creation)
 		glCreateBuffers(1, &ground_texture_handle_buffer);
 		glNamedBufferStorage(
 			ground_texture_handle_buffer,
@@ -390,8 +388,6 @@ export class Terrain: public QObject {
 			ground_texture_handles.data(),
 			GL_DYNAMIC_STORAGE_BIT
 		);
-		glCreateBuffers(1, &ground_exists_buffer);
-		glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
 
 		// Cliff
 		glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &cliff_texture_array);
@@ -422,12 +418,6 @@ export class Terrain: public QObject {
 			sub += 1;
 		}
 		glGenerateTextureMipmap(cliff_texture_array);
-
-		// Water
-		glCreateBuffers(1, &water_height_buffer);
-		glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
-		glCreateBuffers(1, &water_exists_buffer);
-		glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
 
 		// Water textures
 		glCreateTextures(GL_TEXTURE_2D_ARRAY, 1, &water_texture_array);
@@ -466,14 +456,7 @@ export class Terrain: public QObject {
 		cliff_shader = resource_manager.load<Shader>({"data/shaders/cliff.vert", "data/shaders/cliff.frag"});
 		water_shader = resource_manager.load<Shader>({"data/shaders/water.vert", "data/shaders/water.frag"});
 
-		collision_shape =
-			new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
-		collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
-		collision_body->getWorldTransform().setOrigin(
-			btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)
-		); // Bullet centers the collision mesh automatically, we need to decenter it
-		collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
-		physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
+		setup_collision_shape(physics);
 
 		update_ground_textures({0, 0, width - 1, height - 1});
 		update_ground_heights({0, 0, width - 1, height - 1});
@@ -1103,104 +1086,12 @@ export class Terrain: public QObject {
 		update_ground_exists(ramp_area);
 	}
 
-	void resize(size_t new_width, size_t new_height) {
-		//glDeleteTextures(1, &ground_height);
-		//glDeleteTextures(1, &ground_texture_data);
-		//glDeleteTextures(1, &ground_exists);
-
-		//glDeleteTextures(1, &water_exists);
-		//glDeleteTextures(1, &water_height);
-
-		//width = new_width;
-		//height = new_height;
-
-		//auto t = corners[0][0];
-		//corners.clear();
-		//corners.resize(width, std::vector<Corner>(height, t));
-
-		//ground_heights.resize(width * height);
-		//ground_corner_heights.resize(width * height);
-		//ground_texture_list.resize((width - 1) * (height - 1));
-		//ground_exists_data.resize(width * height);
-
-		//water_heights.resize(width * height);
-		//water_exists_data.resize(width * height);
-
-		//for (int i = 0; i < width; i++) {
-		//	for (int j = 0; j < height; j++) {
-		//		ground_corner_heights[j * width + i] = corners[i][j].final_ground_height();
-		//		water_exists_data[j * width + i] = corners[i][j].water;
-		//		ground_heights[j * width + i] = corners[i][j].height;
-		//		water_heights[j * width + i] = corners[i][j].water_height;
-		//	}
-		//}
-
-		//for (int i = 0; i < width - 1; i++) {
-		//	for (int j = 0; j < height - 1; j++) {
-		//		Corner& bottom_left = corners[i][j];
-		//		Corner& bottom_right = corners[i + 1][j];
-		//		Corner& top_left = corners[i][j + 1];
-		//		Corner& top_right = corners[i + 1][j + 1];
-
-		//		bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height || bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
-		//	}
-		//}
-
-		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_height);
-		//glTextureStorage2D(ground_height, 1, GL_R16F, width, height);
-		//glTextureSubImage2D(ground_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_heights.data());
-		//glTextureParameteri(ground_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		//glTextureParameteri(ground_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_corner_height);
-		//glTextureStorage2D(ground_corner_height, 1, GL_R16F, width, height);
-		//glTextureSubImage2D(ground_corner_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, ground_corner_heights.data());
-		//glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
-		//glTextureParameteri(ground_corner_height, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
-
-		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_texture_data);
-		//glTextureStorage2D(ground_texture_data, 1, GL_RGBA16UI, width - 1, height - 1);
-		//glTextureParameteri(ground_texture_data, GL_TEXTURE_MAG_FILTER, GL_NEAREST);
-		//glTextureParameteri(ground_texture_data, GL_TEXTURE_MIN_FILTER, GL_NEAREST);
-
-		//glCreateTextures(GL_TEXTURE_2D, 1, &ground_exists);
-		//glTextureStorage2D(ground_exists, 1, GL_R8, width, height);
-
-		//// Water
-		//glCreateTextures(GL_TEXTURE_2D, 1, &water_height);
-		//glTextureStorage2D(water_height, 1, GL_R16F, width, height);
-		//glTextureSubImage2D(water_height, 0, 0, 0, width, height, GL_RED, GL_FLOAT, water_heights.data());
-
-		//glCreateTextures(GL_TEXTURE_2D, 1, &water_exists);
-		//glTextureStorage2D(water_exists, 1, GL_R8, width, height);
-		//glPixelStorei(GL_UNPACK_ALIGNMENT, 1);
-		//glTextureSubImage2D(water_exists, 0, 0, 0, width, height, GL_RED, GL_UNSIGNED_BYTE, water_exists_data.data());
-		//glPixelStorei(GL_UNPACK_ALIGNMENT, 4);
-
-		//update_cliff_meshes({ 0, 0, width - 1, height - 1 });
-		//update_ground_textures({ 0, 0, width - 1, height - 1 });
-		//update_ground_heights({ 0, 0, width - 1, height - 1 });
-
-		//map->physics.dynamicsWorld->removeRigidBody(collision_body);
-		//delete collision_body;
-		//delete collision_shape;
-
-		//collision_shape = new btHeightfieldTerrainShape(width, height, ground_corner_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
-		//if (collision_shape == nullptr) {
-		//	std::cout << "Error creating Bullet collision shape\n";
-		//}
-		//collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
-		//collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f)); // Bullet centers the collision mesh automatically, we need to decenter it and place it under the player
-		//collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);
-		//map->physics.dynamicsWorld->addRigidBody(collision_body, 32, 32);
-	}
-
-	/// Computes the terrain pathing flags for the target cell.
+	/// Computes the terrain pathing flags for the target cell on the **PATHING** map
 	/// Takes cliffs, blight, water, terrain textures and boundaries into account
 	uint8_t get_terrain_pathing(size_t i, size_t j) {
-		// Use floor division to correctly map pathing cells to corners
-		int corner_x = static_cast<int>(std::floor(i / 4.0));
-		int corner_y = static_cast<int>(std::floor(j / 4.0));
+		// map pathing cell to corner
+		int corner_x = i / 4;
+		int corner_y = j / 4;
 		const Corner& bottom_left = corners[corner_x][corner_y];
 
 		// take terrain texture into account (from the closest corner)
@@ -1216,13 +1107,13 @@ export class Terrain: public QObject {
 
 		// take blight into account
 		if (closest_corner.blight) {
-			mask |= 0b00100000;
+			mask |= PathingMap::blight;
 		}
 
 		// take water into account
 		if (closest_corner.water) {
 			// apply water mask
-			mask |= 0b01000000;
+			mask |= PathingMap::water;
 
 			if (closest_corner.final_water_height(water_offset) > closest_corner.final_ground_height() + 0.40) {
 				// deep water is unwalkable and unbuildable
@@ -1248,20 +1139,8 @@ export class Terrain: public QObject {
 		// places "shadows" on the edges of the map
 		for (size_t i = 0; i < width; i++) {
 			for (size_t j = 0; j < height; j++) {
-				bool is_boundary = false;
-
-				// check all bounduaries
-				if (i < unplayable_left) {
-					is_boundary = true;
-				} else if (i >= width - unplayable_right) {
-					is_boundary = true;
-				} else if (j < unplayable_bottom) {
-					is_boundary = true;
-				} else if (j >= height - unplayable_top) {
-					is_boundary = true;
-				}
-
-				corners[i][j].map_edge = is_boundary;
+				corners[i][j].map_edge =
+					i < unplayable_left || i >= width - unplayable_right || j < unplayable_bottom || j >= height - unplayable_top;
 			}
 		}
 
@@ -1274,17 +1153,13 @@ export class Terrain: public QObject {
 		const int new_height = height + delta_top + delta_bottom;
 
 		// width/height must be at least 33
+		// in reforged, map size is not constrained to multiples of 32
 		if (new_width < 33 || new_height < 33) {
 			return;
 		}
 
 		// maximum map size supported by wc3 is 481 x 481
 		if (new_width > 481 || new_height > 481) {
-			return;
-		}
-
-		// sanity check, (size - 1) must be multiple of 32
-		if (new_width % 32 != 1 || new_height % 32 != 1) {
 			return;
 		}
 
@@ -1307,49 +1182,7 @@ export class Terrain: public QObject {
 		emit minimap_changed(minimap_image());
 	}
 
-	static int get_random_variation() {
-		std::random_device rd;
-		std::mt19937 e2(rd());
-		std::uniform_int_distribution<> dist(0, 570);
-
-		int nr = dist(e2) - 1;
-
-		for (auto&& [variation, chance] : variation_chances) {
-			if (nr < chance) {
-				return variation;
-			}
-			nr -= chance;
-		}
-		assert("Didn't hit the list of tile variations");
-		return 0;
-	}
-
   private:
-	Corner create_default_corner() const {
-		// creates a corner with default values, used when resize destroys the original terrain
-		Corner corner;
-
-		corner.map_edge = false;
-
-		corner.ramp = false;
-		corner.blight = false;
-		corner.water = false;
-		corner.boundary = false;
-		corner.cliff = false;
-		corner.special_doodad = false;
-
-		corner.layer_height = 2;
-		corner.cliff_texture = 15;
-		corner.cliff_variation = 0;
-
-		corner.height = 0;
-		corner.water_height = 0;
-
-		corner.ground_texture = 0;
-
-		return corner;
-	}
-
 	std::vector<std::vector<Corner>> resize_corners(int delta_left, int delta_right, int delta_top, int delta_bottom) const {
 		const int new_width = width + delta_left + delta_right;
 		const int new_height = height + delta_top + delta_bottom;
@@ -1362,13 +1195,11 @@ export class Terrain: public QObject {
 		int old_height_remaining = (int)height + std::min(0, delta_bottom) + std::min(0, delta_top);
 		if (old_width_remaining <= 0 || old_height_remaining <= 0) {
 			// all old corners deleted, fill with default
-			Corner default_corner = create_default_corner();
 			for (size_t i = 0; i < new_width; i++) {
 				for (size_t j = 0; j < new_height; j++) {
 					// apply random tile variation and fix map_edge flag
-					default_corner.ground_variation = get_random_variation();
-					default_corner.map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
-					new_corners[i][j] = default_corner;
+					new_corners[i][j].set_random_variation();
+					new_corners[i][j].map_edge = (i == 0 || i == new_width - 1 || j == 0 || j == new_height - 1);
 				}
 			}
 			return new_corners;
@@ -1396,7 +1227,7 @@ export class Terrain: public QObject {
 				// apply random variations and fix special_doodad for NEW corners
 				if (!is_old_corner) {
 					new_corners[i][j].special_doodad = false;
-					new_corners[i][j].ground_variation = get_random_variation();
+					new_corners[i][j].set_random_variation();
 				}
 			}
 		}
@@ -1423,15 +1254,26 @@ export class Terrain: public QObject {
 			}
 		}
 
-		// resize GPU buffer vectors
-		ground_heights.resize(width * height);
-		final_ground_heights.resize(width * height);
-		ground_texture_list.resize((width - 1) * (height - 1));
-		ground_exists_data.resize(width * height);
-		water_heights.resize(width * height);
-		water_exists_data.resize(width * height);
-
 		// determine cliff flags for all corners
+		compute_cliff_flags();
+
+		// resize and recreate GPU buffers
+		setup_GPU_buffers();
+
+		// update everything else
+		update_ground_heights({0, 0, width, height});
+		update_ground_textures({0, 0, width - 1, height - 1});
+		update_cliff_meshes({0, 0, width - 1, height - 1});
+		update_water({0, 0, width, height});
+
+		// update physics collision shape
+		physics.dynamicsWorld->removeRigidBody(collision_body);
+		delete collision_body;
+		delete collision_shape;
+		setup_collision_shape(physics);
+	}
+
+	void compute_cliff_flags() {
 		for (int i = 0; i < width - 1; i++) {
 			for (int j = 0; j < height - 1; j++) {
 				Corner& bottom_left = corners[i][j];
@@ -1443,8 +1285,18 @@ export class Terrain: public QObject {
 					|| bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
 			}
 		}
+	}
 
-		// recreate GPU buffers with new size
+	void setup_GPU_buffers() {
+		// setup vectors
+		ground_heights.resize(width * height);
+		final_ground_heights.resize(width * height);
+		ground_texture_list.resize((width - 1) * (height - 1));
+		ground_exists_data.resize(width * height);
+		water_heights.resize(width * height);
+		water_exists_data.resize(width * height);
+
+		// ground buffers
 		glCreateBuffers(1, &ground_height_buffer);
 		glNamedBufferStorage(ground_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
 		glCreateBuffers(1, &cliff_level_buffer);
@@ -1453,24 +1305,16 @@ export class Terrain: public QObject {
 		glNamedBufferStorage(ground_texture_data_buffer, (width - 1) * (height - 1) * sizeof(glm::uvec4), nullptr, GL_DYNAMIC_STORAGE_BIT);
 		glCreateBuffers(1, &ground_exists_buffer);
 		glNamedBufferStorage(ground_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+
+		// water buffers
 		glCreateBuffers(1, &water_height_buffer);
 		glNamedBufferStorage(water_height_buffer, width * height * sizeof(float), nullptr, GL_DYNAMIC_STORAGE_BIT);
 		glCreateBuffers(1, &water_exists_buffer);
 		glNamedBufferStorage(water_exists_buffer, width * height * sizeof(uint32_t), nullptr, GL_DYNAMIC_STORAGE_BIT);
+	}
 
-		// update everything else
-		update_ground_heights({0, 0, width, height});
-		update_ground_textures({0, 0, width - 1, height - 1});
-		update_cliff_meshes({0, 0, width - 1, height - 1});
-		update_water({0, 0, width, height});
-
-		// update physics collision shapeated)
-		physics.dynamicsWorld->removeRigidBody(collision_body);
-		delete collision_body;
-		delete collision_shape;
-
-		collision_shape =
-			new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2 /*z*/, PHY_FLOAT, false);
+	void setup_collision_shape(const Physics& physics) {
+		collision_shape = new btHeightfieldTerrainShape(width, height, final_ground_heights.data(), 0, -16.f, 16.f, 2, PHY_FLOAT, false);
 		collision_body = new btRigidBody(0, new btDefaultMotionState(), collision_shape);
 		collision_body->getWorldTransform().setOrigin(btVector3(width / 2.f - 0.5f, height / 2.f - 0.5f, 0.f));
 		collision_body->setCollisionFlags(collision_body->getCollisionFlags() | btCollisionObject::CF_STATIC_OBJECT);

--- a/src/base/units.ixx
+++ b/src/base/units.ixx
@@ -102,7 +102,8 @@ export class Units {
 	static constexpr int write_subversion = 11;
 
 	//static constexpr int mod_table_write_version = 2;
-public:
+
+  public:
 	std::vector<Unit> units;
 	std::vector<Unit> items;
 
@@ -115,13 +116,15 @@ public:
 		}
 		const uint32_t version = reader.read<uint32_t>();
 		if (version != 7 && version != 8) {
-			std::cout << "Unknown war3mapUnits.doo version: " << version << " Attempting to load but may crash\nPlease send this map to eejin\n";
+			std::cout << "Unknown war3mapUnits.doo version: " << version
+					  << " Attempting to load but may crash\nPlease send this map to eejin\n";
 		}
 
 		// Subversion
 		const int subversion = reader.read<uint32_t>();
 		if (subversion != 9 && subversion != 11) {
-			std::cout << "Unknown war3mapUnits.doo subversion: " << subversion << " Attempting to load but may crash\nPlease send this map to eejin\n";
+			std::cout << "Unknown war3mapUnits.doo subversion: " << subversion
+					  << " Attempting to load but may crash\nPlease send this map to eejin\n";
 		}
 
 		const int unit_count = reader.read<uint32_t>();
@@ -159,7 +162,7 @@ public:
 			i.item_sets.resize(reader.read<uint32_t>());
 			for (auto&& j : i.item_sets) {
 				j.items.resize(reader.read<uint32_t>());
-				for (auto&&[chance, id] : j.items) {
+				for (auto&& [chance, id] : j.items) {
 					id = reader.read_string(4);
 					chance = reader.read<uint32_t>();
 				}
@@ -183,10 +186,10 @@ public:
 			}
 
 			i.abilities.resize(reader.read<uint32_t>());
-			for (auto&&[id, autocast, level] : i.abilities) {
+			for (auto&& [id, autocast, level] : i.abilities) {
 				id = reader.read_string(4);
 				autocast = reader.read<uint32_t>();
-				level =  reader.read<uint32_t>();
+				level = reader.read<uint32_t>();
 			}
 
 			i.random_type = reader.read<uint32_t>();
@@ -251,7 +254,7 @@ public:
 				writer.write<uint32_t>(i.item_sets.size());
 				for (auto&& j : i.item_sets) {
 					writer.write<uint32_t>(j.items.size());
-					for (auto&&[chance, id] : j.items) {
+					for (auto&& [chance, id] : j.items) {
 						writer.write_string(id);
 						writer.write<uint32_t>(chance);
 					}
@@ -264,15 +267,14 @@ public:
 				writer.write<uint32_t>(i.agility);
 				writer.write<uint32_t>(i.intelligence);
 
-
 				writer.write<uint32_t>(i.items.size());
-				for (auto&&[slot, id] : i.items) {
+				for (auto&& [slot, id] : i.items) {
 					writer.write<uint32_t>(slot);
 					writer.write_string(id);
 				}
 
 				writer.write<uint32_t>(i.abilities.size());
-				for (auto&&[id, autocast, level] : i.abilities) {
+				for (auto&& [id, autocast, level] : i.abilities) {
 					writer.write_string(id);
 					writer.write<uint32_t>(autocast);
 					writer.write<uint32_t>(level);
@@ -330,7 +332,7 @@ public:
 		unit.position = position;
 		unit.scale = glm::vec3(1.f);
 		unit.angle = 0.f;
-		unit.random = { 1, 0, 0, 0 };
+		unit.random = {1, 0, 0, 0};
 		unit.creation_number = ++Unit::auto_increment;
 		unit.skeleton = SkeletalModelInstance(unit.mesh->mdx, get_required_animation_names(id));
 		unit.update();
@@ -349,7 +351,8 @@ public:
 		units.erase(iterator);
 	}
 
-	[[nodiscard]] std::vector<Unit*> query_area(const QRectF& area) {
+	[[nodiscard]]
+	std::vector<Unit*> query_area(const QRectF& area) {
 		std::vector<Unit*> result;
 
 		for (auto& i : units) {

--- a/src/base/units.ixx
+++ b/src/base/units.ixx
@@ -366,6 +366,12 @@ public:
 		});
 	}
 
+	void remove_items(const std::unordered_set<Unit*>& list) {
+		std::erase_if(items, [&](Unit& item) {
+			return list.contains(&item);
+		});
+	}
+
 	void process_unit_field_change(const std::string& id, const std::string& field) {
 		if (field == "file" || field == "attachmentlinkprops") {
 			id_to_mesh.erase(id);

--- a/src/base/world_undo_manager.ixx
+++ b/src/base/world_undo_manager.ixx
@@ -70,6 +70,13 @@ export class WorldUndoManager {
 		undo_actions.back().push_back(std::move(action));
 		redo_actions.clear();
 	};
+
+	/// Removes all undo/redo operations
+	void clear_all_undo()
+	{
+		undo_actions.clear();
+		redo_actions.clear();
+	}
 };
 
 

--- a/src/base/world_undo_manager.ixx
+++ b/src/base/world_undo_manager.ixx
@@ -69,15 +69,11 @@ export class WorldUndoManager {
 
 		undo_actions.back().push_back(std::move(action));
 		redo_actions.clear();
-	};
+	}
 
 	/// Removes all undo/redo operations
-	void clear_all_undo()
-	{
+	void clear_all_undo() {
 		undo_actions.clear();
 		redo_actions.clear();
 	}
 };
-
-
-

--- a/src/brush/terrain_brush.cpp
+++ b/src/brush/terrain_brush.cpp
@@ -213,7 +213,7 @@ void TerrainBrush::apply(double frame_delta) {
 				} else {
 					corners[i][j].blight = false;
 					corners[i][j].ground_texture = id;
-					corners[i][j].ground_variation = get_random_variation();
+					corners[i][j].ground_variation = Terrain::get_random_variation();
 				}
 			}
 		}
@@ -473,23 +473,6 @@ void TerrainBrush::apply_end() {
 	add_pathing_undo(pathing_area);
 
 	map->terrain.update_minimap();
-}
-
-int TerrainBrush::get_random_variation() const {
-	std::random_device rd;
-	std::mt19937 e2(rd());
-	std::uniform_int_distribution<> dist(0, 570);
-
-	int nr = dist(e2) - 1;
-
-	for (auto&&[variation, chance] : variation_chances) {
-		if (nr < chance) {
-			return variation;
-		}
-		nr -= chance;
-	}
-	assert("Didn't hit the list of tile variations");
-	return 0;
 }
 
 /// Adds the undo to the current undo group

--- a/src/brush/terrain_brush.cpp
+++ b/src/brush/terrain_brush.cpp
@@ -18,7 +18,7 @@ TerrainBrush::TerrainBrush() : Brush() {
 
 void TerrainBrush::mouse_press_event(QMouseEvent* event, double frame_delta) {
 	//if (event->button() == Qt::LeftButton && mode == Mode::selection && !event->modifiers() && input_handler.mouse.y > 0.f) {
-		/*auto id = map->render_manager.pick_unit_id_under_mouse(map->units, input_handler.mouse);
+	/*auto id = map->render_manager.pick_unit_id_under_mouse(map->units, input_handler.mouse);
 		if (id) {
 			Unit& unit = map->units.units[id.value()];
 			selections = { &unit };
@@ -85,7 +85,7 @@ void TerrainBrush::mouse_release_event(QMouseEvent* event) {
 
 // Make this an iterative function instead to avoid stack overflows
 void TerrainBrush::check_nearby(const int begx, const int begy, const int i, const int j, QRect& area) const {
-	QRect bounds = QRect(i - 1, j - 1, 3, 3).intersected({ 0, 0, map->terrain.width, map->terrain.height });
+	QRect bounds = QRect(i - 1, j - 1, 3, 3).intersected({0, 0, map->terrain.width, map->terrain.height});
 
 	for (int k = bounds.x(); k <= bounds.right(); k++) {
 		for (int l = bounds.y(); l <= bounds.bottom(); l++) {
@@ -107,7 +107,7 @@ void TerrainBrush::check_nearby(const int begx, const int begy, const int i, con
 			}
 		}
 	}
-};
+}
 
 void TerrainBrush::apply_begin() {
 	int width = map->terrain.width;
@@ -117,10 +117,10 @@ void TerrainBrush::apply_begin() {
 	const glm::vec2 position = get_position();
 	const int x = position.x + 1;
 	const int y = position.y + 1;
-	const QRect area = QRect(x, y, size.x / 4.f, size.y / 4.f).intersected({ 0, 0, width, height });
+	const QRect area = QRect(x, y, size.x / 4.f, size.y / 4.f).intersected({0, 0, width, height});
 	const int center_x = area.x() + area.width() * 0.5f;
 	const int center_y = area.y() + area.height() * 0.5f;
-	
+
 	// Setup for undo/redo
 	map->world_undo.new_undo_group();
 	old_corners = map->terrain.corners;
@@ -138,7 +138,8 @@ void TerrainBrush::apply_begin() {
 			case cliff_operation::shallow_water:
 				if (!corners[center_x][center_y].water) {
 					layer_height -= 1;
-				} else if (corners[center_x][center_y].final_water_height(map->terrain.water_offset) > corners[center_x][center_y].final_ground_height() + 1) {
+				} else if (corners[center_x][center_y].final_water_height(map->terrain.water_offset)
+						   > corners[center_x][center_y].final_ground_height() + 1) {
 					layer_height += 1;
 				}
 				break;
@@ -151,7 +152,8 @@ void TerrainBrush::apply_begin() {
 			case cliff_operation::deep_water:
 				if (!corners[center_x][center_y].water) {
 					layer_height -= 2;
-				} else if (corners[center_x][center_y].final_water_height(map->terrain.water_offset) < corners[center_x][center_y].final_ground_height() + 1) {
+				} else if (corners[center_x][center_y].final_water_height(map->terrain.water_offset)
+						   < corners[center_x][center_y].final_ground_height() + 1) {
 					layer_height -= 1;
 				}
 				break;
@@ -178,7 +180,7 @@ void TerrainBrush::apply(double frame_delta) {
 	const glm::ivec2 pos = glm::vec2(input_handler.mouse_world) - size.x / 4.f / 2.f + 1.f;
 
 	const glm::vec2 position = get_position();
-	QRect area = QRect(pos.x, pos.y, size.x / 4.f, size.y / 4.f).intersected({ 0, 0, width, height });
+	QRect area = QRect(pos.x, pos.y, size.x / 4.f, size.y / 4.f).intersected({0, 0, width, height});
 
 	if (area.width() <= 0 || area.height() <= 0) {
 		return;
@@ -260,7 +262,7 @@ void TerrainBrush::apply(double frame_delta) {
 
 						for (int k = acum_area.x(); k < acum_area.right() + 1; k++) {
 							for (int l = acum_area.y(); l < acum_area.bottom() + 1; l++) {
-								if ((k < i || l < j) && k <= i && 
+								if ((k < i || l < j) && k <= i &&
 									// The checks below are required because the code is just wrong (area is too small so we cant convolute a cell from at the edges of the area)
 									k - area.x() >= 0 && l - area.y() >= 0 && k < area.right() + 1 && l < area.bottom() + 1) {
 									accumulate += heights[k - area.x()][l - area.y()];
@@ -284,10 +286,9 @@ void TerrainBrush::apply(double frame_delta) {
 		texture_height_area = texture_height_area.united(area);
 	}
 
-	QRect updated_area = QRect(pos.x - 1, pos.y - 1, size.x / 4.f + 1, size.y / 4.f + 1).intersected({ 0, 0, width - 1, height - 1 });
+	QRect updated_area = QRect(pos.x - 1, pos.y - 1, size.x / 4.f + 1, size.y / 4.f + 1).intersected({0, 0, width - 1, height - 1});
 
 	if (apply_cliff) {
-		
 		//if (cliff_operation_type == cliff_operation::ramp) {
 		//	const int center_x = area.x() + area.width() * 0.5f;
 		//	const int center_y = area.y() + area.height() * 0.5f;
@@ -317,45 +318,46 @@ void TerrainBrush::apply(double frame_delta) {
 		//	//	corners[i][j].ramp = true;
 		//	//}
 		//} else {
-			for (int i = area.x(); i < area.x() + area.width(); i++) {
-				for (int j = area.y(); j < area.y() + area.height(); j++) {
-					if (!contains(glm::ivec2(i - area.x(), j - area.y()) - glm::min(glm::ivec2(position) + 1, 0))) {
-						continue;
-					}
-					corners[i][j].ramp = false;
-					corners[i][j].layer_height = layer_height;
-
-					switch (cliff_operation_type) {
-						case cliff_operation::lower1:
-						case cliff_operation::lower2:
-						case cliff_operation::level:
-						case cliff_operation::raise1:
-						case cliff_operation::raise2:
-							if (corners[i][j].water) {
-								if (enforce_water_height_limits && corners[i][j].final_water_height(map->terrain.water_offset) < corners[i][j].final_ground_height()) {
-									corners[i][j].water = false;
-								}
-							}
-							break;
-						case cliff_operation::shallow_water:
-							corners[i][j].water = true;
-							corners[i][j].water_height = corners[i][j].layer_height - 1;
-							break;
-						case cliff_operation::deep_water:
-							corners[i][j].water = true;
-							corners[i][j].water_height = corners[i][j].layer_height;
-							break;
-						case cliff_operation::ramp:
-							break;
-					}
-
-					check_nearby(pos.x, pos.y, i, j, updated_area);
+		for (int i = area.x(); i < area.x() + area.width(); i++) {
+			for (int j = area.y(); j < area.y() + area.height(); j++) {
+				if (!contains(glm::ivec2(i - area.x(), j - area.y()) - glm::min(glm::ivec2(position) + 1, 0))) {
+					continue;
 				}
+				corners[i][j].ramp = false;
+				corners[i][j].layer_height = layer_height;
+
+				switch (cliff_operation_type) {
+					case cliff_operation::lower1:
+					case cliff_operation::lower2:
+					case cliff_operation::level:
+					case cliff_operation::raise1:
+					case cliff_operation::raise2:
+						if (corners[i][j].water) {
+							if (enforce_water_height_limits
+								&& corners[i][j].final_water_height(map->terrain.water_offset) < corners[i][j].final_ground_height()) {
+								corners[i][j].water = false;
+							}
+						}
+						break;
+					case cliff_operation::shallow_water:
+						corners[i][j].water = true;
+						corners[i][j].water_height = corners[i][j].layer_height - 1;
+						break;
+					case cliff_operation::deep_water:
+						corners[i][j].water = true;
+						corners[i][j].water_height = corners[i][j].layer_height;
+						break;
+					case cliff_operation::ramp:
+						break;
+				}
+
+				check_nearby(pos.x, pos.y, i, j, updated_area);
 			}
+		}
 		//}
 
 		// Bounds check
-		updated_area = updated_area.intersected({ 0, 0, width - 1, height - 1 });
+		updated_area = updated_area.intersected({0, 0, width - 1, height - 1});
 
 		// Determine if cliff
 		for (int i = updated_area.x(); i <= updated_area.right(); i++) {
@@ -366,8 +368,7 @@ void TerrainBrush::apply(double frame_delta) {
 				Corner& top_right = map->terrain.corners[i + 1][j + 1];
 
 				bottom_left.cliff = bottom_left.layer_height != bottom_right.layer_height
-					|| bottom_left.layer_height != top_left.layer_height
-					|| bottom_left.layer_height != top_right.layer_height;
+					|| bottom_left.layer_height != top_left.layer_height || bottom_left.layer_height != top_right.layer_height;
 
 				if (cliff_operation_type != cliff_operation::ramp) {
 					bottom_left.cliff_texture = cliff_id;
@@ -375,7 +376,7 @@ void TerrainBrush::apply(double frame_delta) {
 			}
 		}
 
-		QRect tile_area = updated_area.adjusted(-1, -1, 1, 1).intersected({ 0, 0, width - 1, height - 1 });
+		QRect tile_area = updated_area.adjusted(-1, -1, 1, 1).intersected({0, 0, width - 1, height - 1});
 
 		map->terrain.update_cliff_meshes(tile_area);
 		map->terrain.update_ground_textures(updated_area);
@@ -401,8 +402,8 @@ void TerrainBrush::apply(double frame_delta) {
 					uint8_t mask = 0;
 					if ((bottom_left.cliff || bottom_left.romp) && !map->terrain.is_corner_ramp_entrance(i, j) && apply_cliff_pathing) {
 						mask = 0b00001010;
-					} 
-					
+					}
+
 					if (!bottom_left.cliff || (bottom_left.ramp && !bottom_left.romp)) {
 						Corner& corner = map->terrain.corners[i + k / 2][j + l / 2];
 						if (apply_tile_pathing) {
@@ -431,7 +432,14 @@ void TerrainBrush::apply(double frame_delta) {
 		if (change_doodad_heights) {
 			for (auto&& i : map->doodads.doodads) {
 				if (area.contains(i.position.x, i.position.y)) {
-					if (std::find_if(pre_change_doodads.begin(), pre_change_doodads.end(), [i](const Doodad& doodad) { return doodad.creation_number == i.creation_number; }) == pre_change_doodads.end()) {
+					if (std::find_if(
+							pre_change_doodads.begin(),
+							pre_change_doodads.end(),
+							[i](const Doodad& doodad) {
+								return doodad.creation_number == i.creation_number;
+							}
+						)
+						== pre_change_doodads.end()) {
 						pre_change_doodads.push_back(i);
 					}
 					i.position.z = map->terrain.interpolated_height(i.position.x, i.position.y, true);
@@ -454,7 +462,7 @@ void TerrainBrush::apply_end() {
 	}
 
 	if (apply_cliff) {
-		QRect cliff_areaa = cliff_area.adjusted(0, 0, 1, 1).intersected({ 0, 0, map->terrain.width, map->terrain.height });
+		QRect cliff_areaa = cliff_area.adjusted(0, 0, 1, 1).intersected({0, 0, map->terrain.width, map->terrain.height});
 		add_terrain_undo(cliff_areaa, TerrainUndoType::cliff);
 	}
 
@@ -469,7 +477,9 @@ void TerrainBrush::apply_end() {
 		map->world_undo.add_undo_action(std::move(undo));
 	}
 
-	QRect pathing_area = QRect(cliff_area.x() * 4, cliff_area.y() * 4, cliff_area.width() * 4, cliff_area.height() * 4).adjusted(-2, -2, 2, 2).intersected({ 0, 0, map->pathing_map.width, map->pathing_map.height });
+	QRect pathing_area = QRect(cliff_area.x() * 4, cliff_area.y() * 4, cliff_area.width() * 4, cliff_area.height() * 4)
+							 .adjusted(-2, -2, 2, 2)
+							 .intersected({0, 0, map->pathing_map.width, map->pathing_map.height});
 	add_pathing_undo(pathing_area);
 
 	map->terrain.update_minimap();

--- a/src/brush/terrain_brush.cpp
+++ b/src/brush/terrain_brush.cpp
@@ -215,7 +215,7 @@ void TerrainBrush::apply(double frame_delta) {
 				} else {
 					corners[i][j].blight = false;
 					corners[i][j].ground_texture = id;
-					corners[i][j].ground_variation = Terrain::get_random_variation();
+					corners[i][j].set_random_variation();
 				}
 			}
 		}

--- a/src/brush/terrain_brush.h
+++ b/src/brush/terrain_brush.h
@@ -10,8 +10,8 @@ import Doodad;
 import Terrain;
 import TerrainUndo;
 
-class TerrainBrush : public Brush {
-public:
+class TerrainBrush: public Brush {
+  public:
 	bool apply_texture = false;
 	bool apply_height = false;
 	bool apply_cliff = false;
@@ -66,7 +66,7 @@ public:
 	void add_terrain_undo(const QRect& area, TerrainUndoType type);
 	void add_pathing_undo(const QRect& area);
 
-private:
+  private:
 	int layer_height = 0;
 	float deformation_height = 0.f;
 

--- a/src/brush/terrain_brush.h
+++ b/src/brush/terrain_brush.h
@@ -63,34 +63,10 @@ public:
 	void apply(double frame_delta) override;
 	void apply_end() override;
 
-	int get_random_variation() const;
-
 	void add_terrain_undo(const QRect& area, TerrainUndoType type);
 	void add_pathing_undo(const QRect& area);
 
 private:
-	// Total sum 570
-	const std::tuple<int, int> variation_chances[18] = {
-		{ 0, 85 },
-		{ 16, 85 },
-		{ 0, 85 },
-		{ 1, 10 },
-		{ 2, 4 },
-		{ 3, 1 },
-		{ 4, 85 },
-		{ 5, 10 },
-		{ 6, 4 },
-		{ 7, 1 },
-		{ 8, 85 },
-		{ 9, 10 },
-		{ 10, 4 },
-		{ 11, 1 },
-		{ 12, 85 },
-		{ 13, 10 },
-		{ 14, 4 },
-		{ 15, 1 }
-	};
-
 	int layer_height = 0;
 	float deformation_height = 0.f;
 

--- a/src/menus/map_info_editor.cpp
+++ b/src/menus/map_info_editor.cpp
@@ -1,6 +1,7 @@
 #include "map_info_editor.h"
 
 #include <QMessageBox>
+#include <QPainter>
 
 import std;
 import SLK;
@@ -142,7 +143,9 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 	newPlayableBottomLeft = oldPlayableBottomLeft;
 	newPlayableTopRight = oldPlayableTopRight;
 
-	updateSizeDisplays();
+	originalMinimap = map->terrain.minimap_image();
+
+	updateMapSizeGUI();
 
 	// connect arrow buttons to map size
 	connect(ui.mapBoundsLeftDec, &QPushButton::clicked, [this]() { adjustBounds(1, 0, 0, 0); });
@@ -160,6 +163,7 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 		newPlayableBottomLeft.y = newMapBottomLeft.y + 4;
 		newPlayableTopRight.x = newMapTopRight.x - 6;
 		newPlayableTopRight.y = newMapTopRight.y - 8;
+		updateMapSizeGUI();
 	});
 
 	show();
@@ -276,8 +280,15 @@ void MapInfoEditor::save() const {
 	}
 }
 
-void MapInfoEditor::updateSizeDisplays() {
-	// updates the GUI when user presses arrows to change map size
+void MapInfoEditor::updateMapSizeGUI() {
+	// update text in the menu
+	updateBoundsText();
+
+	// update the minimap image
+	updateBoundsPreview();
+}
+
+void MapInfoEditor::updateBoundsText() {
 	int newWidth = newMapTopRight.x - newMapBottomLeft.x;
 	int newHeight = newMapTopRight.y - newMapBottomLeft.y;
 
@@ -287,6 +298,102 @@ void MapInfoEditor::updateSizeDisplays() {
 	// update  map size labels
 	ui.mapSizeFull->setText(QString::fromStdString(std::format("{} x {}", newWidth, newHeight)));
 	ui.mapSizePlayable->setText(QString::fromStdString(std::format("{} x {}", newPlayableWidth, newPlayableHeight)));
+
+	// update map extents and camera bounds text
+	ui.mapBoundsLeft->setText(QString::number(map->terrain.offset.x));
+	ui.mapBoundsRight->setText(QString::number(map->terrain.offset.x + newWidth * 128.f));
+	ui.mapBoundsTop->setText(QString::number(map->terrain.offset.y + newHeight * 128.f));
+	ui.mapBoundsBottom->setText(QString::number(map->terrain.offset.y));
+
+	ui.cameraBoundsLeft->setText(QString::number(map->terrain.offset.x + (newPlayableBottomLeft.x + 4 - newMapBottomLeft.x) * 128.f));
+	ui.cameraBoundsRight->setText(QString::number(map->terrain.offset.x + (newPlayableTopRight.x - 4 - newMapBottomLeft.x) * 128.f));
+	ui.cameraBoundsTop->setText(QString::number(map->terrain.offset.y + (newPlayableTopRight.y - 2 - newMapBottomLeft.y) * 128.f));
+	ui.cameraBoundsBottom->setText(QString::number(map->terrain.offset.y + (newPlayableBottomLeft.y + 2 - newMapBottomLeft.y) * 128.f));
+}
+
+void MapInfoEditor::updateBoundsPreview() {
+	int deltaLeft = oldMapBottomLeft.x - newMapBottomLeft.x;
+	int deltaRight = newMapTopRight.x - oldMapTopRight.x;
+	int deltaBottom = oldMapBottomLeft.y - newMapBottomLeft.y;
+	int deltaTop = newMapTopRight.y - oldMapTopRight.y;
+
+	int newWidth = originalMinimap.width + deltaLeft + deltaRight;
+	int newHeight = originalMinimap.height + deltaBottom + deltaTop;
+
+	Texture newMinimapTex;
+	newMinimapTex.width = newWidth;
+	newMinimapTex.height = newHeight;
+	newMinimapTex.channels = 4;
+	newMinimapTex.data.resize(newWidth * newHeight * 4);
+
+	// crate the new image
+	for (int y = 0; y < newHeight; y++) {
+		for (int x = 0; x < newWidth; x++) {
+			// original coordinates
+			int srcX = x - deltaLeft;
+			int srcY = y - deltaTop;
+
+			int dstIndex = y * newWidth * 4 + x * 4;
+
+			// copy from original image if possible, fill with green otherwise
+			if (srcX >= 0 && srcX < originalMinimap.width && srcY >= 0 && srcY < originalMinimap.height) {
+				int srcIndex = srcY * originalMinimap.width * 4 + srcX * 4;
+				newMinimapTex.data[dstIndex + 0] = originalMinimap.data[srcIndex + 0];
+				newMinimapTex.data[dstIndex + 1] = originalMinimap.data[srcIndex + 1];
+				newMinimapTex.data[dstIndex + 2] = originalMinimap.data[srcIndex + 2];
+				newMinimapTex.data[dstIndex + 3] = originalMinimap.data[srcIndex + 3];
+			} else {
+				newMinimapTex.data[dstIndex + 0] = 0;
+				newMinimapTex.data[dstIndex + 1] = 192;
+				newMinimapTex.data[dstIndex + 2] = 0;
+				newMinimapTex.data[dstIndex + 3] = 255;
+			}
+
+			// check if pixel is in unplayable area
+			int mapX = newMapBottomLeft.x + x;
+			int mapY = newMapTopRight.y - y;
+			bool isUnplayable = (mapX < newPlayableBottomLeft.x || mapX > newPlayableTopRight.x || mapY < newPlayableBottomLeft.y || mapY > newPlayableTopRight.y);
+
+			// unplayable pixels are lighter
+			if (isUnplayable) {
+				newMinimapTex.data[dstIndex + 0] = (newMinimapTex.data[dstIndex + 0] + 255) / 2;
+				newMinimapTex.data[dstIndex + 1] = (newMinimapTex.data[dstIndex + 1] + 255) / 2;
+				newMinimapTex.data[dstIndex + 2] = (newMinimapTex.data[dstIndex + 2] + 255) / 2;
+			}
+		}
+	}
+
+	// create image with transparent background
+	QImage temp_image = QImage(newMinimapTex.data.data(), newMinimapTex.width, newMinimapTex.height, newMinimapTex.width * newMinimapTex.channels, QImage::Format::Format_RGBA8888);
+	QPixmap sourcePixmap = QPixmap::fromImage(temp_image);
+	
+	// scale the pixmap with sharp pixels (no smoothing)
+	QPixmap scaledPixmap = sourcePixmap.scaled(ui.boundsPreview->size(), Qt::KeepAspectRatio, Qt::FastTransformation);
+	
+	// calculate camera bounds in original image coordinates
+	int cameraBoundsLeft = newPlayableBottomLeft.x + 4 - newMapBottomLeft.x;
+	int cameraBoundsBottom = newPlayableBottomLeft.y + 2 - newMapBottomLeft.y;
+	int cameraBoundsRight = newPlayableTopRight.x - 4 - newMapBottomLeft.x;
+	int cameraBoundsTop = newPlayableTopRight.y - 2 - newMapBottomLeft.y;
+	
+	// scale coordinates to match the scaled pixmap
+	float scaleX = static_cast<float>(scaledPixmap.width()) / newWidth;
+	float scaleY = static_cast<float>(scaledPixmap.height()) / newHeight;
+	
+	int scaledLeft = static_cast<int>(cameraBoundsLeft * scaleX);
+	int scaledTop = static_cast<int>((newHeight - cameraBoundsTop - 1) * scaleY);
+	int scaledRight = static_cast<int>(cameraBoundsRight * scaleX);
+	int scaledBottom = static_cast<int>((newHeight - cameraBoundsBottom - 1) * scaleY);
+	
+	// draw camera bounds rectangle on scaled image
+	QPen pen(QColor(0, 120, 255), 2);
+	QPainter painter(&scaledPixmap);
+	painter.setPen(pen);
+	painter.setRenderHint(QPainter::Antialiasing, false);
+	painter.drawRect(scaledLeft, scaledTop, scaledRight - scaledLeft, scaledBottom - scaledTop);
+	painter.end();
+
+	ui.boundsPreview->setPixmap(scaledPixmap);
 }
 
 void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, int deltaBottom) {
@@ -356,5 +463,5 @@ void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, in
 		}
 	}
 
-	updateSizeDisplays();
+	updateMapSizeGUI();
 }

--- a/src/menus/map_info_editor.cpp
+++ b/src/menus/map_info_editor.cpp
@@ -1,5 +1,7 @@
 #include "map_info_editor.h"
 
+#include <QMessageBox>
+
 import std;
 import SLK;
 import Utilities;
@@ -124,6 +126,42 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 		close();
 	});
 
+	// Map size tab
+	// initialise values
+	oldMapBottomLeft.x = 0;
+	oldMapBottomLeft.y = 0;
+	oldMapTopRight.x = map->terrain.width - 1;
+	oldMapTopRight.y = map->terrain.height - 1;
+	newMapTopRight = oldMapTopRight;
+	newMapBottomLeft = oldMapBottomLeft;
+
+	oldPlayableBottomLeft.x = map->info.camera_complements[0];
+	oldPlayableBottomLeft.y = map->info.camera_complements[2];
+	oldPlayableTopRight.x = oldMapTopRight.x - map->info.camera_complements[1];
+	oldPlayableTopRight.y = oldMapTopRight.y - map->info.camera_complements[3];
+	newPlayableBottomLeft = oldPlayableBottomLeft;
+	newPlayableTopRight = oldPlayableTopRight;
+
+	updateSizeDisplays();
+
+	// connect arrow buttons to map size
+	connect(ui.mapBoundsLeftDec, &QPushButton::clicked, [this]() { adjustBounds(1, 0, 0, 0); });
+	connect(ui.mapBoundsLeftInc, &QPushButton::clicked, [this]() { adjustBounds(-1, 0, 0, 0); });
+	connect(ui.mapBoundsRightDec, &QPushButton::clicked, [this]() { adjustBounds(0, -1, 0, 0); });
+	connect(ui.mapBoundsRightInc, &QPushButton::clicked, [this]() { adjustBounds(0, 1, 0, 0); });
+	connect(ui.mapBoundsTopDec, &QPushButton::clicked, [this]() { adjustBounds(0, 0, -1, 0); });
+	connect(ui.mapBoundsTopInc, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 1, 0); });
+	connect(ui.mapBoundsBottomDec, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 0, 1); });
+	connect(ui.mapBoundsBottomInc, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 0, -1); });
+
+	// reset camera bounds (unplayable area) to default
+	connect(ui.resetCameraBounds, &QPushButton::clicked, [this]() {
+		newPlayableBottomLeft.x = newMapBottomLeft.x + 6;
+		newPlayableBottomLeft.y = newMapBottomLeft.y + 4;
+		newPlayableTopRight.x = newMapTopRight.x - 6;
+		newPlayableTopRight.y = newMapTopRight.y - 8;
+	});
+
 	show();
 }
 
@@ -190,4 +228,133 @@ void MapInfoEditor::save() const {
 
 	map->info.water_tinting = ui.waterTinting->isChecked();
 	map->info.water_color = ui.waterColor->get_glm_color();
+
+	// Map size and camera bounds
+	bool changedMapSize = (newMapBottomLeft != oldMapBottomLeft) || (newMapTopRight != oldMapTopRight);
+	bool changedPlayableSize = (newPlayableBottomLeft != oldPlayableBottomLeft) || (newPlayableTopRight != oldPlayableTopRight);
+
+	if (changedMapSize || changedPlayableSize) {
+		int newWidth = newMapTopRight.x - newMapBottomLeft.x;
+		int newHeight = newMapTopRight.y - newMapBottomLeft.y;
+
+		int newPlayableWidth = newPlayableTopRight.x - newPlayableBottomLeft.x;
+		int newPlayableHeight = newPlayableTopRight.y - newPlayableBottomLeft.y;
+
+		if (newWidth < 32 || newWidth > 480 || newHeight < 32 || newHeight > 480) {
+			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be between 32 and 480.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+		}
+		else if (newWidth % 32 != 0 || newHeight % 32 != 0) {
+			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be divisible by 32.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+		}
+		else if (newPlayableWidth < 9 || newPlayableHeight < 5) {
+			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Playable Area", QString("Playable area must be at least 9x5.\nNew playable size would be: %1 x %2").arg(newPlayableWidth).arg(newPlayableHeight));
+		}
+		else {
+			// to make this simpler, we first get rid of old bounduaries
+			if (changedMapSize || changedPlayableSize) {
+				map->set_playable_area(0, 0, 0, 0);
+			}
+
+			// resize the terrain
+			if (changedMapSize) {
+				int deltaLeft = oldMapBottomLeft.x - newMapBottomLeft.x;
+				int deltaRight = newMapTopRight.x - oldMapTopRight.x;
+				int deltaBottom = oldMapBottomLeft.y - newMapBottomLeft.y;
+				int deltaTop = newMapTopRight.y - oldMapTopRight.y;
+				map->resize(deltaLeft, deltaRight, deltaTop, deltaBottom);
+			}
+
+			// apply camera bounds changes
+			if (changedMapSize || changedPlayableSize) {
+				int unplayableLeft = newPlayableBottomLeft.x - newMapBottomLeft.x;
+				int unplayableRight = newMapTopRight.x - newPlayableTopRight.x;
+				int unplayableBottom = newPlayableBottomLeft.y - newMapBottomLeft.y;
+				int unplayableTop = newMapTopRight.y - newPlayableTopRight.y;
+				map->set_playable_area(unplayableLeft, unplayableRight, unplayableTop, unplayableBottom);
+			}
+		}
+	}
+}
+
+void MapInfoEditor::updateSizeDisplays() {
+	// updates the GUI when user presses arrows to change map size
+	int newWidth = newMapTopRight.x - newMapBottomLeft.x;
+	int newHeight = newMapTopRight.y - newMapBottomLeft.y;
+
+	int newPlayableWidth = newPlayableTopRight.x - newPlayableBottomLeft.x;
+	int newPlayableHeight = newPlayableTopRight.y - newPlayableBottomLeft.y;
+
+	// update  map size labels
+	ui.mapSizeFull->setText(QString::fromStdString(std::format("{} x {}", newWidth, newHeight)));
+	ui.mapSizePlayable->setText(QString::fromStdString(std::format("{} x {}", newPlayableWidth, newPlayableHeight)));
+}
+
+void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, int deltaBottom) {
+	int newWidth = newMapTopRight.x - newMapBottomLeft.x;
+	int newHeight = newMapTopRight.y - newMapBottomLeft.y;
+
+	// handle terrain size change
+	if (ui.modifyMapBounds->isChecked()) {
+		// vanilla editor behaviour - changing map is 4 times faster
+		deltaLeft *= 4;
+		deltaRight *= 4;
+		deltaTop *= 4;
+		deltaBottom *= 4;
+
+		// accept the adjustment if the map is within acceptable bounds
+		newWidth += deltaLeft + deltaRight;
+		newHeight += deltaTop + deltaBottom;
+
+		// bounds change
+		if (newWidth >= 32 and newWidth <= 480 and newHeight >= 32 and newHeight <= 480) {
+			newMapBottomLeft.x -= deltaLeft;
+			newMapBottomLeft.y -= deltaBottom;
+			newMapTopRight.x += deltaRight;
+			newMapTopRight.y += deltaTop;
+		}
+	}
+
+	// handle playable area change
+	if (ui.modifyCameraBounds->isChecked()) { 
+		newPlayableBottomLeft.x -= deltaLeft;
+		newPlayableBottomLeft.y -= deltaBottom;
+		newPlayableTopRight.x += deltaRight;
+		newPlayableTopRight.y += deltaTop;
+	}
+
+	// ensure playable area stays within map bounds
+	newPlayableBottomLeft.x = std::max(newPlayableBottomLeft.x, newMapBottomLeft.x);
+	newPlayableBottomLeft.y = std::max(newPlayableBottomLeft.y, newMapBottomLeft.y);
+	newPlayableTopRight.x = std::min(newPlayableTopRight.x, newMapTopRight.x);
+	newPlayableTopRight.y = std::min(newPlayableTopRight.y, newMapTopRight.y);
+
+	// ensure a minimum 9x5 playable area size
+	int playableWidth = newPlayableTopRight.x - newPlayableBottomLeft.x;
+	int playableHeight = newPlayableTopRight.y - newPlayableBottomLeft.y;
+
+	if (playableWidth < 9) {
+		int deficit = 9 - playableWidth;
+		// expand playable area on the opposite side to compensate
+		if (deltaLeft != 0) {
+			// left was adjusted, expand right
+			newPlayableTopRight.x += deficit;
+		} else if (deltaRight != 0) {
+			// right was adjusted, expand left
+			newPlayableBottomLeft.x -= deficit;
+		}
+	}
+
+	if (playableHeight < 5) {
+		int deficit = 5 - playableHeight;
+		// expand playable area on the opposite side to compensate
+		if (deltaBottom != 0) {
+			// bottom was adjusted, expand top
+			newPlayableTopRight.y += deficit;
+		} else if (deltaTop != 0) {
+			// top was adjusted, expand bottom
+			newPlayableBottomLeft.y -= deficit;
+		}
+	}
+
+	updateSizeDisplays();
 }

--- a/src/menus/map_info_editor.cpp
+++ b/src/menus/map_info_editor.cpp
@@ -116,17 +116,6 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 	ui.gameDataSet->setCurrentIndex(map->info.game_data_set);
 
 
-	connect(ui.buttonBox, &QDialogButtonBox::accepted, [&]() {
-		save();
-		emit accept();
-		close();
-	});
-
-	connect(ui.buttonBox, &QDialogButtonBox::rejected, [&]() {
-		emit reject();
-		close();
-	});
-
 	// Map size tab
 	// initialise values
 	oldMapBottomLeft.x = 0;
@@ -145,8 +134,6 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 
 	originalMinimap = map->terrain.minimap_image();
 
-	updateMapSizeGUI();
-
 	// connect arrow buttons to map size
 	connect(ui.mapBoundsLeftDec, &QPushButton::clicked, [this]() { adjustBounds(1, 0, 0, 0); });
 	connect(ui.mapBoundsLeftInc, &QPushButton::clicked, [this]() { adjustBounds(-1, 0, 0, 0); });
@@ -164,12 +151,25 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 		newPlayableTopRight.x = newMapTopRight.x - 6;
 		newPlayableTopRight.y = newMapTopRight.y - 8;
 		updateMapSizeGUI();
+	});	
+
+	connect(ui.buttonBox, &QDialogButtonBox::accepted, [&]() {
+		if (save()) {
+			emit accept();
+			close();
+		}
+	});
+
+	connect(ui.buttonBox, &QDialogButtonBox::rejected, [&]() {
+		emit reject();
+		close();
 	});
 
 	show();
+	updateMapSizeGUI();
 }
 
-void MapInfoEditor::save() const {
+bool MapInfoEditor::save() const {
 	// Description Tab
 	map->trigger_strings.set_string(map->info.name, ui.name->text().toStdString());
 	map->trigger_strings.set_string(map->info.author, ui.author->text().toStdString());
@@ -246,12 +246,15 @@ void MapInfoEditor::save() const {
 
 		if (newWidth < 32 || newWidth > 480 || newHeight < 32 || newHeight > 480) {
 			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be between 32 and 480.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+			return false;
 		}
 		else if (newWidth % 32 != 0 || newHeight % 32 != 0) {
 			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be divisible by 32.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+			return false;
 		}
 		else if (newPlayableWidth < 9 || newPlayableHeight < 5) {
 			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Playable Area", QString("Playable area must be at least 9x5.\nNew playable size would be: %1 x %2").arg(newPlayableWidth).arg(newPlayableHeight));
+			return false;
 		}
 		else {
 			// to make this simpler, we first get rid of old bounduaries
@@ -278,6 +281,7 @@ void MapInfoEditor::save() const {
 			}
 		}
 	}
+	return true;
 }
 
 void MapInfoEditor::updateMapSizeGUI() {
@@ -295,20 +299,47 @@ void MapInfoEditor::updateBoundsText() {
 	int newPlayableWidth = newPlayableTopRight.x - newPlayableBottomLeft.x;
 	int newPlayableHeight = newPlayableTopRight.y - newPlayableBottomLeft.y;
 
+	float offsetX = map->terrain.offset.x + (newMapBottomLeft.x - oldMapBottomLeft.x) * 128.f;
+	float offsetY = map->terrain.offset.y + (newMapBottomLeft.y - oldMapBottomLeft.y) * 128.f;
+
 	// update  map size labels
 	ui.mapSizeFull->setText(QString::fromStdString(std::format("{} x {}", newWidth, newHeight)));
 	ui.mapSizePlayable->setText(QString::fromStdString(std::format("{} x {}", newPlayableWidth, newPlayableHeight)));
 
 	// update map extents and camera bounds text
-	ui.mapBoundsLeft->setText(QString::number(map->terrain.offset.x));
-	ui.mapBoundsRight->setText(QString::number(map->terrain.offset.x + newWidth * 128.f));
-	ui.mapBoundsTop->setText(QString::number(map->terrain.offset.y + newHeight * 128.f));
-	ui.mapBoundsBottom->setText(QString::number(map->terrain.offset.y));
+	ui.mapBoundsLeft->setText(QString::number(offsetX));
+	ui.mapBoundsRight->setText(QString::number(offsetX + newWidth * 128.f));
+	ui.mapBoundsTop->setText(QString::number(offsetY + newHeight * 128.f));
+	ui.mapBoundsBottom->setText(QString::number(offsetY));
 
-	ui.cameraBoundsLeft->setText(QString::number(map->terrain.offset.x + (newPlayableBottomLeft.x + 4 - newMapBottomLeft.x) * 128.f));
-	ui.cameraBoundsRight->setText(QString::number(map->terrain.offset.x + (newPlayableTopRight.x - 4 - newMapBottomLeft.x) * 128.f));
-	ui.cameraBoundsTop->setText(QString::number(map->terrain.offset.y + (newPlayableTopRight.y - 2 - newMapBottomLeft.y) * 128.f));
-	ui.cameraBoundsBottom->setText(QString::number(map->terrain.offset.y + (newPlayableBottomLeft.y + 2 - newMapBottomLeft.y) * 128.f));
+	ui.cameraBoundsLeft->setText(QString::number(offsetX + (newPlayableBottomLeft.x + 4 - newMapBottomLeft.x) * 128.f));
+	ui.cameraBoundsRight->setText(QString::number(offsetX + (newPlayableTopRight.x - 4 - newMapBottomLeft.x) * 128.f));
+	ui.cameraBoundsTop->setText(QString::number(offsetY + (newPlayableTopRight.y - 2 - newMapBottomLeft.y) * 128.f));
+	ui.cameraBoundsBottom->setText(QString::number(offsetY + (newPlayableBottomLeft.y + 2 - newMapBottomLeft.y) * 128.f));
+
+	// map size text - determine size based on surface area
+	int surfaceArea = newWidth * newHeight;
+	QString sizeDescription;
+	
+	if (surfaceArea <= 80 * 80) {
+		sizeDescription = "Tiny";
+	} else if (surfaceArea <= 112 * 112) {
+		sizeDescription = "Extra Small";
+	} else if (surfaceArea <= 144 * 144) {
+		sizeDescription = "Small";
+	} else if (surfaceArea <= 176 * 176) {
+		sizeDescription = "Medium";
+	} else if (surfaceArea <= 208 * 208) {
+		sizeDescription = "Large";
+	} else if (surfaceArea <= 272 * 272) {
+		sizeDescription = "Extra Large";
+	} else if (surfaceArea <= 364 * 364) {
+		sizeDescription = "Huge";
+	} else {
+		sizeDescription = "Epic";
+	}
+	
+	ui.mapSizeDescription->setText(sizeDescription);
 }
 
 void MapInfoEditor::updateBoundsPreview() {
@@ -400,6 +431,9 @@ void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, in
 	int newWidth = newMapTopRight.x - newMapBottomLeft.x;
 	int newHeight = newMapTopRight.y - newMapBottomLeft.y;
 
+	int offsetX = static_cast<int>(map->terrain.offset.x / 128.0f);
+	int offsetY = static_cast<int>(map->terrain.offset.y / 128.0f);
+
 	// handle terrain size change
 	if (ui.modifyMapBounds->isChecked()) {
 		// vanilla editor behaviour - changing map is 4 times faster
@@ -412,8 +446,18 @@ void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, in
 		newWidth += deltaLeft + deltaRight;
 		newHeight += deltaTop + deltaBottom;
 
+		// check if the map is not too large, or too small
+		bool allowedSize = newWidth >= 32 and newWidth <= 480 and newHeight >= 32 and newHeight <= 480;
+
+		// check if the map extents are valid (vanilla WE constraint)
+		int leftExtent = newMapBottomLeft.x + offsetX - deltaLeft;
+		int rightExtent = newMapTopRight.x + offsetX + deltaRight;
+		int topExtent = newMapTopRight.y + offsetY + deltaTop;
+		int bottomExtent = newMapBottomLeft.y + offsetY - deltaBottom;
+		bool validExtents = (leftExtent >= -252 && rightExtent <= 252 && bottomExtent >= -252 && topExtent <= 252);
+
 		// bounds change
-		if (newWidth >= 32 and newWidth <= 480 and newHeight >= 32 and newHeight <= 480) {
+		if (allowedSize && validExtents) {
 			newMapBottomLeft.x -= deltaLeft;
 			newMapBottomLeft.y -= deltaBottom;
 			newMapTopRight.x += deltaRight;

--- a/src/menus/map_info_editor.cpp
+++ b/src/menus/map_info_editor.cpp
@@ -274,13 +274,6 @@ bool MapInfoEditor::save() const {
 				QString("Map dimensions must be between 32 and 480.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight)
 			);
 			return false;
-		} else if (newWidth % 32 != 0 || newHeight % 32 != 0) {
-			QMessageBox::critical(
-				const_cast<MapInfoEditor*>(this),
-				"Invalid Map Size",
-				QString("Map dimensions must be divisible by 32.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight)
-			);
-			return false;
 		} else if (newPlayableWidth < 9 || newPlayableHeight < 5) {
 			QMessageBox::critical(
 				const_cast<MapInfoEditor*>(this),

--- a/src/menus/map_info_editor.cpp
+++ b/src/menus/map_info_editor.cpp
@@ -11,7 +11,7 @@ import Globals;
 
 namespace fs = std::filesystem;
 
-MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
+MapInfoEditor::MapInfoEditor(QWidget* parent) : QDialog(parent) {
 	ui.setupUi(this);
 	setAttribute(Qt::WA_DeleteOnClose);
 
@@ -25,7 +25,7 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 	ui.editorVersion->setText(QString::number(map->info.editor_version));
 
 	// Loading Screen Tab
-	for (auto&&[key, value] : world_edit_data.section("LoadingScreens")) {
+	for (auto&& [key, value] : world_edit_data.section("LoadingScreens")) {
 		if (key == "NumScreens") {
 			continue;
 		}
@@ -41,7 +41,7 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 		}
 	}
 
-	for (auto&&[key, value] : world_edit_data.section("LoadingScreens")) {
+	for (auto&& [key, value] : world_edit_data.section("LoadingScreens")) {
 		if (key == "NumScreens") {
 			continue;
 		}
@@ -87,9 +87,12 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 
 	ui.globalWeather->setChecked(map->info.weather_id != 0);
 	for (size_t i = 1; i < weather_slk.rows(); i++) {
-		ui.globalWeatherCombo->addItem(QString::fromUtf8(weather_slk.data<std::string_view>("name", i)), QString::fromUtf8(weather_slk.data<std::string_view>("effectid", i)));
+		ui.globalWeatherCombo->addItem(
+			QString::fromUtf8(weather_slk.data<std::string_view>("name", i)),
+			QString::fromUtf8(weather_slk.data<std::string_view>("effectid", i))
+		);
 	}
-	std::string weather_id = { reinterpret_cast<char*>(&map->info.weather_id), 4 };
+	std::string weather_id = {reinterpret_cast<char*>(&map->info.weather_id), 4};
 	ui.globalWeatherCombo->setCurrentText(QString::fromUtf8(weather_slk.data<std::string_view>("name", weather_id)));
 
 	// Custom Sound
@@ -98,9 +101,14 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 
 	ui.customSound->setChecked(!map->info.custom_sound_environment.empty());
 	for (size_t i = 1; i < environment_sounds_slk.rows(); i++) {
-		ui.customSoundCombo->addItem(QString::fromUtf8(environment_sounds_slk.data<std::string_view>("displaytext", i)), QString::fromUtf8(environment_sounds_slk.data<std::string_view>("environmenttype", i)));
+		ui.customSoundCombo->addItem(
+			QString::fromUtf8(environment_sounds_slk.data<std::string_view>("displaytext", i)),
+			QString::fromUtf8(environment_sounds_slk.data<std::string_view>("environmenttype", i))
+		);
 	}
-	ui.customSoundCombo->setCurrentText(QString::fromUtf8(environment_sounds_slk.data<std::string_view>("displaytext", map->info.custom_sound_environment)));
+	ui.customSoundCombo->setCurrentText(
+		QString::fromUtf8(environment_sounds_slk.data<std::string_view>("displaytext", map->info.custom_sound_environment))
+	);
 
 	// Custom Lighting
 	for (auto&& [key, value] : world_edit_data.section("TileSets")) {
@@ -114,7 +122,6 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 
 	ui.itemClassification->setChecked(map->info.item_classification);
 	ui.gameDataSet->setCurrentIndex(map->info.game_data_set);
-
 
 	// Map size tab
 	// initialise values
@@ -135,14 +142,30 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 	originalMinimap = map->terrain.minimap_image();
 
 	// connect arrow buttons to map size
-	connect(ui.mapBoundsLeftDec, &QPushButton::clicked, [this]() { adjustBounds(1, 0, 0, 0); });
-	connect(ui.mapBoundsLeftInc, &QPushButton::clicked, [this]() { adjustBounds(-1, 0, 0, 0); });
-	connect(ui.mapBoundsRightDec, &QPushButton::clicked, [this]() { adjustBounds(0, -1, 0, 0); });
-	connect(ui.mapBoundsRightInc, &QPushButton::clicked, [this]() { adjustBounds(0, 1, 0, 0); });
-	connect(ui.mapBoundsTopDec, &QPushButton::clicked, [this]() { adjustBounds(0, 0, -1, 0); });
-	connect(ui.mapBoundsTopInc, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 1, 0); });
-	connect(ui.mapBoundsBottomDec, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 0, 1); });
-	connect(ui.mapBoundsBottomInc, &QPushButton::clicked, [this]() { adjustBounds(0, 0, 0, -1); });
+	connect(ui.mapBoundsLeftDec, &QPushButton::clicked, [this]() {
+		adjustBounds(1, 0, 0, 0);
+	});
+	connect(ui.mapBoundsLeftInc, &QPushButton::clicked, [this]() {
+		adjustBounds(-1, 0, 0, 0);
+	});
+	connect(ui.mapBoundsRightDec, &QPushButton::clicked, [this]() {
+		adjustBounds(0, -1, 0, 0);
+	});
+	connect(ui.mapBoundsRightInc, &QPushButton::clicked, [this]() {
+		adjustBounds(0, 1, 0, 0);
+	});
+	connect(ui.mapBoundsTopDec, &QPushButton::clicked, [this]() {
+		adjustBounds(0, 0, -1, 0);
+	});
+	connect(ui.mapBoundsTopInc, &QPushButton::clicked, [this]() {
+		adjustBounds(0, 0, 1, 0);
+	});
+	connect(ui.mapBoundsBottomDec, &QPushButton::clicked, [this]() {
+		adjustBounds(0, 0, 0, 1);
+	});
+	connect(ui.mapBoundsBottomInc, &QPushButton::clicked, [this]() {
+		adjustBounds(0, 0, 0, -1);
+	});
 
 	// reset camera bounds (unplayable area) to default
 	connect(ui.resetCameraBounds, &QPushButton::clicked, [this]() {
@@ -151,7 +174,7 @@ MapInfoEditor::MapInfoEditor(QWidget *parent) : QDialog(parent) {
 		newPlayableTopRight.x = newMapTopRight.x - 6;
 		newPlayableTopRight.y = newMapTopRight.y - 8;
 		updateMapSizeGUI();
-	});	
+	});
 
 	connect(ui.buttonBox, &QDialogButtonBox::accepted, [&]() {
 		if (save()) {
@@ -245,18 +268,29 @@ bool MapInfoEditor::save() const {
 		int newPlayableHeight = newPlayableTopRight.y - newPlayableBottomLeft.y;
 
 		if (newWidth < 32 || newWidth > 480 || newHeight < 32 || newHeight > 480) {
-			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be between 32 and 480.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+			QMessageBox::critical(
+				const_cast<MapInfoEditor*>(this),
+				"Invalid Map Size",
+				QString("Map dimensions must be between 32 and 480.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight)
+			);
 			return false;
-		}
-		else if (newWidth % 32 != 0 || newHeight % 32 != 0) {
-			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Map Size", QString("Map dimensions must be divisible by 32.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight));
+		} else if (newWidth % 32 != 0 || newHeight % 32 != 0) {
+			QMessageBox::critical(
+				const_cast<MapInfoEditor*>(this),
+				"Invalid Map Size",
+				QString("Map dimensions must be divisible by 32.\nNew size would be: %1 x %2").arg(newWidth).arg(newHeight)
+			);
 			return false;
-		}
-		else if (newPlayableWidth < 9 || newPlayableHeight < 5) {
-			QMessageBox::critical(const_cast<MapInfoEditor*>(this), "Invalid Playable Area", QString("Playable area must be at least 9x5.\nNew playable size would be: %1 x %2").arg(newPlayableWidth).arg(newPlayableHeight));
+		} else if (newPlayableWidth < 9 || newPlayableHeight < 5) {
+			QMessageBox::critical(
+				const_cast<MapInfoEditor*>(this),
+				"Invalid Playable Area",
+				QString("Playable area must be at least 9x5.\nNew playable size would be: %1 x %2")
+					.arg(newPlayableWidth)
+					.arg(newPlayableHeight)
+			);
 			return false;
-		}
-		else {
+		} else {
 			// to make this simpler, we first get rid of old bounduaries
 			if (changedMapSize || changedPlayableSize) {
 				map->set_playable_area(0, 0, 0, 0);
@@ -320,7 +354,7 @@ void MapInfoEditor::updateBoundsText() {
 	// map size text - determine size based on surface area
 	int surfaceArea = newWidth * newHeight;
 	QString sizeDescription;
-	
+
 	if (surfaceArea <= 80 * 80) {
 		sizeDescription = "Tiny";
 	} else if (surfaceArea <= 112 * 112) {
@@ -338,7 +372,7 @@ void MapInfoEditor::updateBoundsText() {
 	} else {
 		sizeDescription = "Epic";
 	}
-	
+
 	ui.mapSizeDescription->setText(sizeDescription);
 }
 
@@ -383,7 +417,9 @@ void MapInfoEditor::updateBoundsPreview() {
 			// check if pixel is in unplayable area
 			int mapX = newMapBottomLeft.x + x;
 			int mapY = newMapTopRight.y - y;
-			bool isUnplayable = (mapX < newPlayableBottomLeft.x || mapX > newPlayableTopRight.x || mapY < newPlayableBottomLeft.y || mapY > newPlayableTopRight.y);
+			bool isUnplayable =
+				(mapX < newPlayableBottomLeft.x || mapX > newPlayableTopRight.x || mapY < newPlayableBottomLeft.y
+				 || mapY > newPlayableTopRight.y);
 
 			// unplayable pixels are lighter
 			if (isUnplayable) {
@@ -395,27 +431,33 @@ void MapInfoEditor::updateBoundsPreview() {
 	}
 
 	// create image with transparent background
-	QImage temp_image = QImage(newMinimapTex.data.data(), newMinimapTex.width, newMinimapTex.height, newMinimapTex.width * newMinimapTex.channels, QImage::Format::Format_RGBA8888);
+	QImage temp_image = QImage(
+		newMinimapTex.data.data(),
+		newMinimapTex.width,
+		newMinimapTex.height,
+		newMinimapTex.width * newMinimapTex.channels,
+		QImage::Format::Format_RGBA8888
+	);
 	QPixmap sourcePixmap = QPixmap::fromImage(temp_image);
-	
+
 	// scale the pixmap with sharp pixels (no smoothing)
 	QPixmap scaledPixmap = sourcePixmap.scaled(ui.boundsPreview->size(), Qt::KeepAspectRatio, Qt::FastTransformation);
-	
+
 	// calculate camera bounds in original image coordinates
 	int cameraBoundsLeft = newPlayableBottomLeft.x + 4 - newMapBottomLeft.x;
 	int cameraBoundsBottom = newPlayableBottomLeft.y + 2 - newMapBottomLeft.y;
 	int cameraBoundsRight = newPlayableTopRight.x - 4 - newMapBottomLeft.x;
 	int cameraBoundsTop = newPlayableTopRight.y - 2 - newMapBottomLeft.y;
-	
+
 	// scale coordinates to match the scaled pixmap
 	float scaleX = static_cast<float>(scaledPixmap.width()) / newWidth;
 	float scaleY = static_cast<float>(scaledPixmap.height()) / newHeight;
-	
+
 	int scaledLeft = static_cast<int>(cameraBoundsLeft * scaleX);
 	int scaledTop = static_cast<int>((newHeight - cameraBoundsTop - 1) * scaleY);
 	int scaledRight = static_cast<int>(cameraBoundsRight * scaleX);
 	int scaledBottom = static_cast<int>((newHeight - cameraBoundsBottom - 1) * scaleY);
-	
+
 	// draw camera bounds rectangle on scaled image
 	QPen pen(QColor(0, 120, 255), 2);
 	QPainter painter(&scaledPixmap);
@@ -466,7 +508,7 @@ void MapInfoEditor::adjustBounds(int deltaLeft, int deltaRight, int deltaTop, in
 	}
 
 	// handle playable area change
-	if (ui.modifyCameraBounds->isChecked()) { 
+	if (ui.modifyCameraBounds->isChecked()) {
 		newPlayableBottomLeft.x -= deltaLeft;
 		newPlayableBottomLeft.y -= deltaBottom;
 		newPlayableTopRight.x += deltaRight;

--- a/src/menus/map_info_editor.h
+++ b/src/menus/map_info_editor.h
@@ -6,6 +6,8 @@
 
 #include "ui_map_info_editor.h"
 
+import Texture;
+
 class MapInfoEditor : public QDialog {
 	Q_OBJECT
 
@@ -15,4 +17,21 @@ public:
 	Ui::MapInfoEditor ui;
 
 	void save() const;
+
+private:
+	void updateSizeDisplays();
+	void adjustBounds(int deltaLeft, int deltaRight, int deltaTop, int deltaBottom);
+
+	// used for changing map size
+	glm::vec2 oldMapBottomLeft;
+	glm::vec2 oldMapTopRight;
+	glm::vec2 newMapBottomLeft;
+	glm::vec2 newMapTopRight;
+
+	glm::vec2 oldPlayableBottomLeft;
+	glm::vec2 oldPlayableTopRight;
+	glm::vec2 newPlayableBottomLeft;
+	glm::vec2 newPlayableTopRight;
+
+	Texture newMinimapTex;
 };

--- a/src/menus/map_info_editor.h
+++ b/src/menus/map_info_editor.h
@@ -19,19 +19,21 @@ public:
 	void save() const;
 
 private:
-	void updateSizeDisplays();
+	void updateMapSizeGUI();
 	void adjustBounds(int deltaLeft, int deltaRight, int deltaTop, int deltaBottom);
+	void updateBoundsPreview();
+	void updateBoundsText();
 
 	// used for changing map size
-	glm::vec2 oldMapBottomLeft;
-	glm::vec2 oldMapTopRight;
-	glm::vec2 newMapBottomLeft;
-	glm::vec2 newMapTopRight;
+	glm::ivec2 oldMapBottomLeft;
+	glm::ivec2 oldMapTopRight;
+	glm::ivec2 newMapBottomLeft;
+	glm::ivec2 newMapTopRight;
 
-	glm::vec2 oldPlayableBottomLeft;
-	glm::vec2 oldPlayableTopRight;
-	glm::vec2 newPlayableBottomLeft;
-	glm::vec2 newPlayableTopRight;
+	glm::ivec2 oldPlayableBottomLeft;
+	glm::ivec2 oldPlayableTopRight;
+	glm::ivec2 newPlayableBottomLeft;
+	glm::ivec2 newPlayableTopRight;
 
-	Texture newMinimapTex;
+	Texture originalMinimap;
 };

--- a/src/menus/map_info_editor.h
+++ b/src/menus/map_info_editor.h
@@ -8,17 +8,17 @@
 
 import Texture;
 
-class MapInfoEditor : public QDialog {
+class MapInfoEditor: public QDialog {
 	Q_OBJECT
 
-public:
+  public:
 	MapInfoEditor(QWidget* parent = nullptr);
 
 	Ui::MapInfoEditor ui;
 
 	bool save() const;
 
-private:
+  private:
 	void updateMapSizeGUI();
 	void adjustBounds(int deltaLeft, int deltaRight, int deltaTop, int deltaBottom);
 	void updateBoundsPreview();

--- a/src/menus/map_info_editor.h
+++ b/src/menus/map_info_editor.h
@@ -16,7 +16,7 @@ public:
 
 	Ui::MapInfoEditor ui;
 
-	void save() const;
+	bool save() const;
 
 private:
 	void updateMapSizeGUI();

--- a/src/menus/map_info_editor.ui
+++ b/src/menus/map_info_editor.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>376</width>
-    <height>527</height>
+    <width>582</width>
+    <height>556</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -116,104 +116,6 @@
             </widget>
            </item>
           </layout>
-         </item>
-        </layout>
-       </widget>
-       <widget class="QWidget" name="tab_4">
-        <attribute name="title">
-         <string>Loading Screen</string>
-        </attribute>
-        <layout class="QVBoxLayout" name="verticalLayout_4">
-         <item>
-          <widget class="QLabel" name="label_7">
-           <property name="text">
-            <string>Loading Screen Graphic</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <layout class="QFormLayout" name="formLayout_3">
-           <item row="0" column="0">
-            <widget class="QRadioButton" name="useDefaultLoadingScreen">
-             <property name="text">
-              <string>Use Default Screen</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">loadingScreenGraphicGroup</string>
-             </attribute>
-            </widget>
-           </item>
-           <item row="1" column="0">
-            <widget class="QRadioButton" name="useCampaignLoadingScreen">
-             <property name="text">
-              <string>Use Campaign Screen</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">loadingScreenGraphicGroup</string>
-             </attribute>
-            </widget>
-           </item>
-           <item row="2" column="0">
-            <widget class="QRadioButton" name="useImportedLoadingScreen">
-             <property name="text">
-              <string>Use Imported File</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">loadingScreenGraphicGroup</string>
-             </attribute>
-            </widget>
-           </item>
-           <item row="1" column="1">
-            <widget class="QComboBox" name="campaignLoadingScreen">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="maxVisibleItems">
-              <number>20</number>
-             </property>
-            </widget>
-           </item>
-           <item row="2" column="1">
-            <widget class="QComboBox" name="importedLoadingScreen">
-             <property name="enabled">
-              <bool>false</bool>
-             </property>
-             <property name="maxVisibleItems">
-              <number>20</number>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_14">
-           <property name="text">
-            <string>Loading Screen Title</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="loadingScreenTitle"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_15">
-           <property name="text">
-            <string>Loading Screen Subtitle</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QLineEdit" name="loadingScreenSubtitle"/>
-         </item>
-         <item>
-          <widget class="QLabel" name="label_16">
-           <property name="text">
-            <string>Loading Screen Text</string>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPlainTextEdit" name="loadingScreenText"/>
          </item>
         </layout>
        </widget>
@@ -473,26 +375,7 @@
          </item>
         </layout>
        </widget>
-       <widget class="QWidget" name="tab_5">
-        <attribute name="title">
-         <string>Preferences</string>
-        </attribute>
-        <widget class="QLabel" name="label_17">
-         <property name="geometry">
-          <rect>
-           <x>160</x>
-           <y>170</y>
-           <width>47</width>
-           <height>13</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>?</string>
-         </property>
-        </widget>
-       </widget>
-
-        <widget class="QWidget" name="tab_6">
+       <widget class="QWidget" name="tab_6">
         <attribute name="title">
          <string>Size and Camera Bounds</string>
         </attribute>
@@ -502,38 +385,117 @@
            <item row="1" column="0">
             <layout class="QVBoxLayout" name="verticalLayout_left">
              <item>
-              <widget class="QLabel" name="label_mapLeft">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+              <spacer name="verticalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
                </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_mapLeft">
                <property name="text">
                 <string>Map</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="mapBoundsLeft">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
                <property name="text">
                 <string>0</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_leftArrows">
+               <property name="topMargin">
+                <number>8</number>
+               </property>
+               <property name="bottomMargin">
+                <number>8</number>
+               </property>
                <item>
                 <widget class="QPushButton" name="mapBoundsLeftDec">
+                 <property name="minimumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <family>Consolas</family>
+                   <pointsize>14</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>◀</string>
+                 </property>
+                 <property name="autoRepeat">
+                  <bool>true</bool>
+                 </property>
+                 <property name="fixedSize" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
                  </property>
                 </widget>
                </item>
                <item>
+                <layout class="QVBoxLayout" name="verticalLayout_11"/>
+               </item>
+               <item>
                 <widget class="QPushButton" name="mapBoundsLeftInc">
+                 <property name="minimumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <family>Consolas</family>
+                   <pointsize>14</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>▶</string>
+                 </property>
+                 <property name="autoRepeat">
+                  <bool>true</bool>
+                 </property>
+                 <property name="autoRepeatDelay">
+                  <number>304</number>
+                 </property>
+                 <property name="fixedSize" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
                  </property>
                 </widget>
                </item>
@@ -541,23 +503,51 @@
              </item>
              <item>
               <widget class="QLabel" name="label_cameraLeft">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
                <property name="text">
                 <string>Camera</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="cameraBoundsLeft">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
                <property name="text">
                 <string>0</string>
                </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
               </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::MinimumExpanding</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </item>
@@ -566,68 +556,186 @@
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_top">
                <item>
-                <widget class="QLabel" name="label_mapTop">
-                 <property name="text">
-                  <string>Map</string>
+                <spacer name="horizontalSpacer_3">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                </widget>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
                <item>
-                <widget class="QLabel" name="mapBoundsTop">
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                <layout class="QVBoxLayout" name="verticalLayout_12">
+                 <property name="spacing">
+                  <number>0</number>
                  </property>
-                 <property name="text">
-                  <string>0</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_topArrows">
                  <item>
-                  <widget class="QPushButton" name="mapBoundsTopInc">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>20</height>
-                    </size>
+                  <widget class="QLabel" name="label_mapTop">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>▲</string>
+                    <string>Map</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="mapBoundsTopDec">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>20</height>
-                    </size>
+                  <widget class="QLabel" name="mapBoundsTop">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>▼</string>
+                    <string>0</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                 </layout>
                </item>
                <item>
-                <widget class="QLabel" name="label_cameraTop">
-                 <property name="text">
-                  <string>Camera</string>
+                <layout class="QVBoxLayout" name="verticalLayout_topArrows">
+                 <property name="leftMargin">
+                  <number>8</number>
                  </property>
-                </widget>
+                 <property name="rightMargin">
+                  <number>8</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsTopInc">
+                   <property name="minimumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <family>Consolas</family>
+                     <pointsize>14</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>▲</string>
+                   </property>
+                   <property name="autoRepeat">
+                    <bool>true</bool>
+                   </property>
+                   <property name="fixedSize" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsTopDec">
+                   <property name="minimumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <family>Consolas</family>
+                     <pointsize>14</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>▼</string>
+                   </property>
+                   <property name="autoRepeat">
+                    <bool>true</bool>
+                   </property>
+                   <property name="fixedSize" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
                <item>
-                <widget class="QLabel" name="cameraBoundsTop">
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                <layout class="QVBoxLayout" name="verticalLayout_13">
+                 <property name="spacing">
+                  <number>0</number>
                  </property>
-                 <property name="text">
-                  <string>0</string>
+                 <item>
+                  <widget class="QLabel" name="label_cameraTop">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Camera</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="cameraBoundsTop">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>0</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_4">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                </widget>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </item>
@@ -635,6 +743,12 @@
            </item>
            <item row="1" column="1">
             <widget class="QLabel" name="boundsPreview">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
              <property name="minimumSize">
               <size>
                <width>300</width>
@@ -642,10 +756,19 @@
               </size>
              </property>
              <property name="styleSheet">
-              <string notr="true">background-color: rgb(128, 128, 128);</string>
+              <string notr="true">background-color: transparent;</string>
+             </property>
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Plain</enum>
              </property>
              <property name="text">
-              <string/>
+              <string>Image</string>
+             </property>
+             <property name="scaledContents">
+              <bool>false</bool>
              </property>
              <property name="alignment">
               <set>Qt::AlignCenter</set>
@@ -655,38 +778,111 @@
            <item row="1" column="2">
             <layout class="QVBoxLayout" name="verticalLayout_right">
              <item>
-              <widget class="QLabel" name="label_mapRight">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
+              <spacer name="verticalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
                </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_mapRight">
                <property name="text">
                 <string>Map</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="mapBoundsRight">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
                <property name="text">
                 <string>0</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_rightArrows">
+               <property name="topMargin">
+                <number>8</number>
+               </property>
+               <property name="bottomMargin">
+                <number>8</number>
+               </property>
                <item>
                 <widget class="QPushButton" name="mapBoundsRightDec">
+                 <property name="minimumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <family>Consolas</family>
+                   <pointsize>14</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>◀</string>
+                 </property>
+                 <property name="autoRepeat">
+                  <bool>true</bool>
+                 </property>
+                 <property name="fixedSize" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
                  </property>
                 </widget>
                </item>
                <item>
                 <widget class="QPushButton" name="mapBoundsRightInc">
+                 <property name="minimumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="maximumSize">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                 <property name="font">
+                  <font>
+                   <family>Consolas</family>
+                   <pointsize>14</pointsize>
+                  </font>
+                 </property>
                  <property name="text">
                   <string>▶</string>
+                 </property>
+                 <property name="autoRepeat">
+                  <bool>true</bool>
+                 </property>
+                 <property name="fixedSize" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>20</height>
+                  </size>
                  </property>
                 </widget>
                </item>
@@ -694,23 +890,36 @@
              </item>
              <item>
               <widget class="QLabel" name="label_cameraRight">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
                <property name="text">
                 <string>Camera</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
                </property>
               </widget>
              </item>
              <item>
               <widget class="QLabel" name="cameraBoundsRight">
-               <property name="alignment">
-                <set>Qt::AlignCenter</set>
-               </property>
                <property name="text">
                 <string>0</string>
                </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
               </widget>
+             </item>
+             <item>
+              <spacer name="verticalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Vertical</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>40</height>
+                </size>
+               </property>
+              </spacer>
              </item>
             </layout>
            </item>
@@ -719,68 +928,186 @@
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_bottom">
                <item>
-                <widget class="QLabel" name="label_mapBottom">
-                 <property name="text">
-                  <string>Map</string>
+                <spacer name="horizontalSpacer_2">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                </widget>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
                <item>
-                <widget class="QLabel" name="mapBoundsBottom">
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                <layout class="QVBoxLayout" name="verticalLayout_8">
+                 <property name="spacing">
+                  <number>0</number>
                  </property>
-                 <property name="text">
-                  <string>0</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <layout class="QVBoxLayout" name="verticalLayout_bottomArrows">
                  <item>
-                  <widget class="QPushButton" name="mapBoundsBottomInc">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>20</height>
-                    </size>
+                  <widget class="QLabel" name="label_mapBottom">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>▲</string>
+                    <string>Map</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                  <item>
-                  <widget class="QPushButton" name="mapBoundsBottomDec">
-                   <property name="maximumSize">
-                    <size>
-                     <width>16777215</width>
-                     <height>20</height>
-                    </size>
+                  <widget class="QLabel" name="mapBoundsBottom">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
                    </property>
                    <property name="text">
-                    <string>▼</string>
+                    <string>0</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
                    </property>
                   </widget>
                  </item>
                 </layout>
                </item>
                <item>
-                <widget class="QLabel" name="label_cameraBottom">
-                 <property name="text">
-                  <string>Camera</string>
+                <layout class="QVBoxLayout" name="verticalLayout_bottomArrows">
+                 <property name="leftMargin">
+                  <number>8</number>
                  </property>
-                </widget>
+                 <property name="rightMargin">
+                  <number>8</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsBottomInc">
+                   <property name="minimumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <family>Consolas</family>
+                     <pointsize>14</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>▲</string>
+                   </property>
+                   <property name="autoRepeat">
+                    <bool>true</bool>
+                   </property>
+                   <property name="fixedSize" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsBottomDec">
+                   <property name="minimumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="maximumSize">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="font">
+                    <font>
+                     <family>Consolas</family>
+                     <pointsize>14</pointsize>
+                    </font>
+                   </property>
+                   <property name="text">
+                    <string>▼</string>
+                   </property>
+                   <property name="autoRepeat">
+                    <bool>true</bool>
+                   </property>
+                   <property name="fixedSize" stdset="0">
+                    <size>
+                     <width>20</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
                </item>
                <item>
-                <widget class="QLabel" name="cameraBoundsBottom">
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
+                <layout class="QVBoxLayout" name="verticalLayout_9">
+                 <property name="spacing">
+                  <number>0</number>
                  </property>
-                 <property name="text">
-                  <string>0</string>
+                 <item>
+                  <widget class="QLabel" name="label_cameraBottom">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>Camera</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QLabel" name="cameraBoundsBottom">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="text">
+                    <string>0</string>
+                   </property>
+                   <property name="alignment">
+                    <set>Qt::AlignCenter</set>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <spacer name="horizontalSpacer_5">
+                 <property name="orientation">
+                  <enum>Qt::Horizontal</enum>
                  </property>
-                </widget>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>40</width>
+                   <height>20</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </item>
@@ -796,6 +1123,9 @@
               <widget class="QCheckBox" name="modifyCameraBounds">
                <property name="text">
                 <string>Modify Camera Bounds</string>
+               </property>
+               <property name="checked">
+                <bool>true</bool>
                </property>
               </widget>
              </item>
@@ -823,13 +1153,6 @@
            </item>
            <item>
             <layout class="QVBoxLayout" name="verticalLayout_mapInfo">
-             <item>
-              <widget class="QLabel" name="label_mapSizeInfo">
-               <property name="text">
-                <string>Map Size:</string>
-               </property>
-              </widget>
-             </item>
              <item>
               <layout class="QHBoxLayout" name="horizontalLayout_description">
                <item>
@@ -897,7 +1220,122 @@
          </item>
         </layout>
        </widget>
-
+       <widget class="QWidget" name="tab_4">
+        <attribute name="title">
+         <string>Loading Screen</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_7">
+           <property name="text">
+            <string>Loading Screen Graphic</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <layout class="QFormLayout" name="formLayout_3">
+           <item row="0" column="0">
+            <widget class="QRadioButton" name="useDefaultLoadingScreen">
+             <property name="text">
+              <string>Use Default Screen</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loadingScreenGraphicGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="1" column="0">
+            <widget class="QRadioButton" name="useCampaignLoadingScreen">
+             <property name="text">
+              <string>Use Campaign Screen</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loadingScreenGraphicGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="2" column="0">
+            <widget class="QRadioButton" name="useImportedLoadingScreen">
+             <property name="text">
+              <string>Use Imported File</string>
+             </property>
+             <attribute name="buttonGroup">
+              <string notr="true">loadingScreenGraphicGroup</string>
+             </attribute>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QComboBox" name="campaignLoadingScreen">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="maxVisibleItems">
+              <number>20</number>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QComboBox" name="importedLoadingScreen">
+             <property name="enabled">
+              <bool>false</bool>
+             </property>
+             <property name="maxVisibleItems">
+              <number>20</number>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_14">
+           <property name="text">
+            <string>Loading Screen Title</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="loadingScreenTitle"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_15">
+           <property name="text">
+            <string>Loading Screen Subtitle</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLineEdit" name="loadingScreenSubtitle"/>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_16">
+           <property name="text">
+            <string>Loading Screen Text</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPlainTextEdit" name="loadingScreenText"/>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_5">
+        <attribute name="title">
+         <string>Preferences</string>
+        </attribute>
+        <widget class="QLabel" name="label_17">
+         <property name="geometry">
+          <rect>
+           <x>160</x>
+           <y>170</y>
+           <width>47</width>
+           <height>13</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>?</string>
+         </property>
+        </widget>
+       </widget>
       </widget>
      </item>
      <item>

--- a/src/menus/map_info_editor.ui
+++ b/src/menus/map_info_editor.ui
@@ -491,6 +491,413 @@
          </property>
         </widget>
        </widget>
+
+        <widget class="QWidget" name="tab_6">
+        <attribute name="title">
+         <string>Size and Camera Bounds</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <layout class="QGridLayout" name="gridLayout_bounds">
+           <item row="1" column="0">
+            <layout class="QVBoxLayout" name="verticalLayout_left">
+             <item>
+              <widget class="QLabel" name="label_mapLeft">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>Map</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="mapBoundsLeft">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_leftArrows">
+               <item>
+                <widget class="QPushButton" name="mapBoundsLeftDec">
+                 <property name="text">
+                  <string>◀</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="mapBoundsLeftInc">
+                 <property name="text">
+                  <string>▶</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_cameraLeft">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>Camera</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="cameraBoundsLeft">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="0" column="1">
+            <layout class="QVBoxLayout" name="verticalLayout_top">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_top">
+               <item>
+                <widget class="QLabel" name="label_mapTop">
+                 <property name="text">
+                  <string>Map</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="mapBoundsTop">
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_topArrows">
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsTopInc">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>▲</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsTopDec">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>▼</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_cameraTop">
+                 <property name="text">
+                  <string>Camera</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="cameraBoundsTop">
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="boundsPreview">
+             <property name="minimumSize">
+              <size>
+               <width>300</width>
+               <height>300</height>
+              </size>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">background-color: rgb(128, 128, 128);</string>
+             </property>
+             <property name="text">
+              <string/>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="2">
+            <layout class="QVBoxLayout" name="verticalLayout_right">
+             <item>
+              <widget class="QLabel" name="label_mapRight">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>Map</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="mapBoundsRight">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_rightArrows">
+               <item>
+                <widget class="QPushButton" name="mapBoundsRightDec">
+                 <property name="text">
+                  <string>◀</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QPushButton" name="mapBoundsRightInc">
+                 <property name="text">
+                  <string>▶</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <widget class="QLabel" name="label_cameraRight">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>Camera</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="cameraBoundsRight">
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+               <property name="text">
+                <string>0</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="2" column="1">
+            <layout class="QVBoxLayout" name="verticalLayout_bottom">
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_bottom">
+               <item>
+                <widget class="QLabel" name="label_mapBottom">
+                 <property name="text">
+                  <string>Map</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="mapBoundsBottom">
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <layout class="QVBoxLayout" name="verticalLayout_bottomArrows">
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsBottomInc">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>▲</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="mapBoundsBottomDec">
+                   <property name="maximumSize">
+                    <size>
+                     <width>16777215</width>
+                     <height>20</height>
+                    </size>
+                   </property>
+                   <property name="text">
+                    <string>▼</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </item>
+               <item>
+                <widget class="QLabel" name="label_cameraBottom">
+                 <property name="text">
+                  <string>Camera</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="cameraBoundsBottom">
+                 <property name="alignment">
+                  <set>Qt::AlignCenter</set>
+                 </property>
+                 <property name="text">
+                  <string>0</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <layout class="QHBoxLayout" name="horizontalLayout_bottomInfo">
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_checkboxes">
+             <item>
+              <widget class="QCheckBox" name="modifyCameraBounds">
+               <property name="text">
+                <string>Modify Camera Bounds</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QCheckBox" name="modifyMapBounds">
+               <property name="text">
+                <string>Modify Map Bounds</string>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <spacer name="horizontalSpacer_bounds">
+             <property name="orientation">
+              <enum>Qt::Horizontal</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>40</width>
+               <height>20</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <layout class="QVBoxLayout" name="verticalLayout_mapInfo">
+             <item>
+              <widget class="QLabel" name="label_mapSizeInfo">
+               <property name="text">
+                <string>Map Size:</string>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_description">
+               <item>
+                <widget class="QLabel" name="label_descriptionLabel">
+                 <property name="text">
+                  <string>Description:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="mapSizeDescription">
+                 <property name="text">
+                  <string>Tiny</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_playable">
+               <item>
+                <widget class="QLabel" name="label_playableLabel">
+                 <property name="text">
+                  <string>Playable:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="mapSizePlayable">
+                 <property name="text">
+                  <string>52 x 52</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item>
+              <layout class="QHBoxLayout" name="horizontalLayout_full">
+               <item>
+                <widget class="QLabel" name="label_fullLabel">
+                 <property name="text">
+                  <string>Full:</string>
+                 </property>
+                </widget>
+               </item>
+               <item>
+                <widget class="QLabel" name="mapSizeFull">
+                 <property name="text">
+                  <string>64 x 64</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </item>
+         <item>
+          <widget class="QPushButton" name="resetCameraBounds">
+           <property name="text">
+            <string>Reset Camera Bounds to Defaults</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </widget>
+
       </widget>
      </item>
      <item>


### PR DESCRIPTION
Allows the user to change the map size and camera bounds via the _Size and Camera Bounds_ tab in the options menu.

Additional changes:
- Move `get_random_variation` from `TerrainBrush` to `Terrain` so it can be used by both the brush and the resize tool
- Add `get_terrain_pathing` to `Terrain` to reset pathing for a given cell
- Re-add `ShadowMap` to `Map`