### PR TITLE
Scenario info editor

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -139,6 +139,7 @@ target_sources(HiveWE_lib PRIVATE
 
 	"menus/doodad_palette.cpp"
 	"menus/map_info_editor.cpp"
+	"menus/scenario_info_editor.cpp"
 	"menus/map_protection_dialog.cpp"
 	"menus/map_protection_dialog.h"
 	"menus/minimap.cpp"

--- a/src/base/map_info.ixx
+++ b/src/base/map_info.ixx
@@ -472,6 +472,8 @@ export class MapInfo {
 			.enemy_low_priorities_flags = 0,
 			.enemy_high_priorities_flags = 0,
 		} };
+		trigger_strings.set_string(players[0].name, "Player 1");
+
 		forces = { ForceData {
 			.allied = false,
 			.allied_victory = false,
@@ -481,6 +483,8 @@ export class MapInfo {
 			.player_masks = static_cast<int>(0xFFFFFFFF),
 			.name = "",
 		} };
+		trigger_strings.set_string(forces[0].name, "Force 1");
+
 		available_upgrades.clear();
 		available_tech.clear();
 		random_unit_tables.clear();

--- a/src/main_window/hivewe.cpp
+++ b/src/main_window/hivewe.cpp
@@ -23,6 +23,7 @@ import "object_editor/object_editor.h";
 import "model_editor/model_editor.h";
 import "tile_setter.h";
 import "map_info_editor.h";
+import "scenario_info_editor.h";
 import "terrain_palette.h";
 import "settings_editor.h";
 import "map_protection_dialog.h";
@@ -218,12 +219,31 @@ HiveWE::HiveWE(QWidget* parent) : QMainWindow(parent) {
 		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(0);
 	});
 	connect(ui.ribbon->map_loading_screen, &QRibbonButton::clicked, [&]() {
-		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(1);
+		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(3);	// NOTE: Used to be index 1 which opened the wrong tab (Options)
 	});
 	connect(ui.ribbon->map_options, &QRibbonButton::clicked, [&]() {
-		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(2);
+		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(1);	// NOTE: Used to be index 2 which opened the wrong tab (Size and Camera Bounds)
 	});
 	// connect(ui, &QAction::triggered, [&]() { (new MapInfoEditor(this))->ui.tabs->setCurrentIndex(3); });
+
+	connect(ui.ribbon->player_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(0);
+	});
+	connect(ui.ribbon->ally_priorities_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(1);
+	});
+	connect(ui.ribbon->force_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(2);
+	});
+	connect(ui.ribbon->techtree_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(3);
+	});
+	connect(ui.ribbon->ability_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(4);
+	});
+	connect(ui.ribbon->upgrade_properties, &QRibbonButton::clicked, [&]() {
+		(new ScenarioInfoEditor(this))->ui.tabs->setCurrentIndex(5);
+	});
 
 	connect(new QShortcut(QKeySequence(Qt::Key_T), this, nullptr, nullptr, Qt::WindowShortcut), &QShortcut::activated, [&]() {
 		open_palette<TerrainPalette>();

--- a/src/main_window/hivewe.cpp
+++ b/src/main_window/hivewe.cpp
@@ -219,10 +219,10 @@ HiveWE::HiveWE(QWidget* parent) : QMainWindow(parent) {
 		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(0);
 	});
 	connect(ui.ribbon->map_loading_screen, &QRibbonButton::clicked, [&]() {
-		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(3);	// NOTE: Used to be index 1 which opened the wrong tab (Options)
+		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(3);
 	});
 	connect(ui.ribbon->map_options, &QRibbonButton::clicked, [&]() {
-		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(1);	// NOTE: Used to be index 2 which opened the wrong tab (Size and Camera Bounds)
+		(new MapInfoEditor(this))->ui.tabs->setCurrentIndex(1);
 	});
 	// connect(ui, &QAction::triggered, [&]() { (new MapInfoEditor(this))->ui.tabs->setCurrentIndex(3); });
 

--- a/src/main_window/main_ribbon.cpp
+++ b/src/main_window/main_ribbon.cpp
@@ -230,6 +230,7 @@ MainRibbon::MainRibbon(QWidget* parent) : QRibbon(parent) {
 	// Map tab
 	QRibbonTab* map_tab = new QRibbonTab;
 
+	// Map section
 	QRibbonSection* map_section = new QRibbonSection;
 
 	map_description->setIcon(QIcon("data/icons/ribbon/description.png"));
@@ -257,6 +258,35 @@ MainRibbon::MainRibbon(QWidget* parent) : QRibbon(parent) {
 	//map_section->addWidget(map_size_camera_bounds);
 
 	map_tab->addSection(map_section);
+
+	// Scenario section
+	QRibbonSection* scenario_section = new QRibbonSection;
+
+	player_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	player_properties->setText("Player\nProperties");
+	scenario_section->addWidget(player_properties);
+
+	ally_priorities_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	ally_priorities_properties->setText("Ally Priorities\nProperties");
+	scenario_section->addWidget(ally_priorities_properties);
+
+	force_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	force_properties->setText("Force\nProperties");
+	scenario_section->addWidget(force_properties);
+
+	techtree_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	techtree_properties->setText("Techtree\nProperties");
+	scenario_section->addWidget(techtree_properties);
+
+	ability_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	ability_properties->setText("Ability\nProperties");
+	scenario_section->addWidget(ability_properties);
+
+	upgrade_properties->setIcon(QIcon("data/icons/ribbon/options.png"));
+	upgrade_properties->setText("Upgrade\nProperties");
+	scenario_section->addWidget(upgrade_properties);
+
+	map_tab->addSection(scenario_section);
 
 	// Tools tab
 	QRibbonTab* tools_tab = new QRibbonTab;

--- a/src/main_window/main_ribbon.h
+++ b/src/main_window/main_ribbon.h
@@ -38,6 +38,13 @@ public:
 	QRibbonButton* gameplay_constants = new QRibbonButton;
 	QRibbonButton* map_protection = new QRibbonButton;
 
+	QRibbonButton* player_properties = new QRibbonButton;
+	QRibbonButton* ally_priorities_properties = new QRibbonButton;
+	QRibbonButton* force_properties = new QRibbonButton;
+	QRibbonButton* techtree_properties = new QRibbonButton;
+	QRibbonButton* ability_properties = new QRibbonButton;
+	QRibbonButton* upgrade_properties = new QRibbonButton;
+
 	QRibbonButton* import_heightmap = new QRibbonButton;
 	QRibbonButton* change_tileset = new QRibbonButton;
 	QRibbonButton* change_tile_pathing = new QRibbonButton;

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -54,10 +54,12 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		"00781e",	// Emerald (0.000, 0.471, 0.118)
 		"a56e34",	// Peanut (0.647, 0.435, 0.204)
 		// Unused (Included for completeness)
+		/*
 		"2e2d2e",	// Black (0.180, 0.176, 0.180)
 		"2e2d2e",	// Black (0.180, 0.176, 0.180)
 		"2e2d2e",	// Black (0.180, 0.176, 0.180)
 		"2e2d2e"	// Black (0.180, 0.176, 0.180)
+		*/
 	};
 
 	// Player Properties tab
@@ -150,20 +152,20 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 	}
 
 	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton *button) {
-		// Restoring Player 1 defaults
-		player_rows[0].name->setText("");
-		player_rows[0].name->setEnabled(true);
-
-		player_rows[0].race->setCurrentIndex(0);
-		player_rows[0].race->setEnabled(true);
-
-		player_rows[0].controller->setCurrentIndex(1);
-
-		player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
-		player_rows[0].fixed_start_position->setEnabled(true);
-
-		// Restoring Player 2 - 24 defaults
 		if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole) {
+			// Restoring Player 1 defaults
+			player_rows[0].name->setText("");
+			player_rows[0].name->setEnabled(true);
+
+			player_rows[0].race->setCurrentIndex(0);
+			player_rows[0].race->setEnabled(true);
+
+			player_rows[0].controller->setCurrentIndex(1);
+
+			player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+			player_rows[0].fixed_start_position->setEnabled(true);
+
+			// Restoring Player 2 - 24 defaults
 			for (int i = 1; i < 24; i++) {
 				std::string name = "Player " + std::to_string(i+1);
 				player_rows[i].name->setText(QString::fromStdString(name));
@@ -218,7 +220,7 @@ bool ScenarioInfoEditor::save() const {
 		// Controller == None ?
 		if (controller_type == 0) {
 			if (found_index != -1) {
-				map->info.players.erase(map->info.players.begin() + slot);
+				map->info.players.erase(map->info.players.begin() + found_index);
 			}
 			continue;
 		}
@@ -229,15 +231,15 @@ bool ScenarioInfoEditor::save() const {
 			auto& new_player = map->info.players.emplace_back();
 			
 			new_player.internal_number = slot;
-			new_player.type = PlayerType::human,
-			new_player.race = PlayerRace::human,
-			new_player.fixed_start_position = 0,
-			new_player.name = "",
-			new_player.starting_position = { 0.f, 0.f },
-			new_player.ally_low_priorities_flags = 0,
-			new_player.ally_high_priorities_flags = 0,
-			new_player.enemy_low_priorities_flags = 0,
-			new_player.enemy_high_priorities_flags = 0,
+			new_player.type = PlayerType::human;
+			new_player.race = PlayerRace::human;
+			new_player.fixed_start_position = 0;
+			new_player.name = "";
+			new_player.starting_position = { 0.f, 0.f };
+			new_player.ally_low_priorities_flags = 0;
+			new_player.ally_high_priorities_flags = 0;
+			new_player.enemy_low_priorities_flags = 0;
+			new_player.enemy_high_priorities_flags = 0;
 
 			found_index = map->info.players.size()-1;
 		}
@@ -287,6 +289,28 @@ bool ScenarioInfoEditor::save() const {
 
 
 void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex) {
+	// Is NOT controller type Human ?
+	if (controllerTypeIndex != 1) {
+		// Is there any other controller type Human player ?
+		bool found_human = false;
+		for (int i = 0; i < 24; i++) {
+			if (player_rows[i].controller->currentIndex() == 1) {
+				found_human = true;
+				break;
+			}
+		}
+
+		if (found_human == false) {
+			player_rows[slotIndex].controller->setCurrentIndex(1);
+			player_rows[slotIndex].name->setEnabled(true);
+			player_rows[slotIndex].race->setEnabled(true);
+			player_rows[slotIndex].fixed_start_position->setEnabled(true);
+			QMessageBox::information(this, "ScenarioInfoEditor error", "At least one player must be human controlled.");
+			return;
+		}
+	}
+
+	// Is controller type None ?
 	if (controllerTypeIndex == 0) {
 		player_rows[slotIndex].name->setEnabled(false);
 		player_rows[slotIndex].race->setEnabled(false);

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -106,16 +106,16 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		
 		switch (player.type) {
 		case PlayerType::human:
-			player_rows[player.internal_number].controller->setCurrentIndex(1);
+			player_rows[player.internal_number].controller->setCurrentIndex(ControllerType::user);
 			break;
 		case PlayerType::computer:
-			player_rows[player.internal_number].controller->setCurrentIndex(2);
+			player_rows[player.internal_number].controller->setCurrentIndex(ControllerType::computer);
 			break;
 		case PlayerType::neutral:
-			player_rows[player.internal_number].controller->setCurrentIndex(3);
+			player_rows[player.internal_number].controller->setCurrentIndex(ControllerType::neutral);
 			break;
 		case PlayerType::rescuable:
-			player_rows[player.internal_number].controller->setCurrentIndex(4);
+			player_rows[player.internal_number].controller->setCurrentIndex(ControllerType::rescuable);
 			break;
 		}
 
@@ -190,8 +190,7 @@ bool ScenarioInfoEditor::save() const {
 			}
 		}
 
-		// Controller == None ?
-		if (controller_type == 0) {
+		if (controller_type == ControllerType::none) {
 			if (found_index != -1) {
 				map->info.players.erase(map->info.players.begin() + found_index);
 			}
@@ -262,19 +261,18 @@ bool ScenarioInfoEditor::save() const {
 
 
 void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex) {
-	// Is controller type NOT Human ?
-	if (controllerTypeIndex != 1) {
-		// Is there any other Human controller type ?
+	if (controllerTypeIndex != ControllerType::user) {
+		// Is there any other User controller type ?
 		bool found_human = false;
 		for (const auto& player : player_rows) {
-			if (player.controller->currentIndex() == 1) {
+			if (player.controller->currentIndex() == ControllerType::user) {
 				found_human = true;
 				break;
 			}
 		}
 
 		if (found_human == false) {
-			player_rows[slotIndex].controller->setCurrentIndex(1);
+			player_rows[slotIndex].controller->setCurrentIndex(ControllerType::user);
 			player_rows[slotIndex].name->setEnabled(true);
 			player_rows[slotIndex].race->setEnabled(true);
 			player_rows[slotIndex].fixed_start_position->setEnabled(true);
@@ -283,8 +281,7 @@ void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex
 		}
 	}
 
-	// Is controller type None ?
-	if (controllerTypeIndex == 0) {
+	if (controllerTypeIndex == ControllerType::none) {
 		player_rows[slotIndex].name->setEnabled(false);
 		player_rows[slotIndex].race->setEnabled(false);
 		player_rows[slotIndex].fixed_start_position->setEnabled(false);
@@ -317,7 +314,7 @@ void ScenarioInfoEditor::restoreDefaults() {
 
 void ScenarioInfoEditor::restorePlayerProperties() {
 	// Restoring Player 1 defaults
-	player_rows[0].controller->setCurrentIndex(1);
+	player_rows[0].controller->setCurrentIndex(ControllerType::user);
 
 	player_rows[0].name->setText("Player 1");
 	player_rows[0].name->setEnabled(true);
@@ -330,9 +327,9 @@ void ScenarioInfoEditor::restorePlayerProperties() {
 
 	// Restoring Player 2 - 24 defaults
 	for (int i = 1; i < 24; i++) {
-		player_rows[i].controller->setCurrentIndex(0);
+		player_rows[i].controller->setCurrentIndex(ControllerType::none);
 
-		std::string name = "Player " + std::to_string(i+1);
+		const std::string name = "Player " + std::to_string(i+1);
 		player_rows[i].name->setText(QString::fromStdString(name));
 		player_rows[i].name->setEnabled(false);
 

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -2,7 +2,6 @@
 
 #include <QMessageBox>
 #include <QPainter>
-#include "map_protection_dialog.h"
 #include <vector>
 #include <string>
 

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -1,0 +1,299 @@
+#include "scenario_info_editor.h"
+
+#include <QMessageBox>
+#include <QPainter>
+#include "map_protection_dialog.h"
+#include <vector>
+#include <string>
+
+import std;
+import SLK;
+import Utilities;
+import MapGlobal;
+import Globals;
+import Tileset;
+
+namespace fs = std::filesystem;
+
+ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
+    ui.setupUi(this);
+    setAttribute(Qt::WA_DeleteOnClose);
+    
+	// Temporary local declaration of player colours in hex code.
+	// TODO/Future work: expose the player colours for access from other modules
+	// and preferably in float or u8 rgb values with utility/helper functions
+	// for conversion to hex codes.
+	// Player colours were manually calculated based on the values in data/shaders/skinned_mesh_sd.vert with
+	// an exact copy in data/shaders/skinned_mesh_hd.vert, data/shaders/editable_mesh_hd.vert and
+	// data/shaders/editable_mesh_sd.vert.
+	// These exposed player colour could then be uploaded into the shaders to avoid duplicate
+	// definitions in the shaders.
+	std::vector<std::string> player_colors = {
+		"ff0303",	// Red (1.000, 0.012, 0.012)
+		"0042ff",	// Blue (0.000, 0.259, 1.000)
+		"1be7ba",	// Teal (0.106, 0.906, 0.729)
+		"550081",	// Purple (0.333, 0.000, 0.506)
+		"fefc00",	// Yellow (0.996, 0.988, 0.000)
+		"fe890d",	// Orange (0.996, 0.537, 0.051)
+		"21bf00",	// Green (0.129, 0.749, 0.000)
+		"e45caf",	// Pink (0.894, 0.361, 0.686)
+		"939596",	// Gray (0.576, 0.584, 0.588)
+		"7ebff1",	// Light Blue (0.494, 0.749, 0.945)
+		"106247",	// Dark Green (0.063, 0.384, 0.278)
+		"4f2b05",	// Brown (0.310, 0.169, 0.020)
+		"9c0000",	// Maroon (0.612, 0.000, 0.000)
+		"0000c3",	// Navy (0.000, 0.000, 0.765)
+		"00ebff",	// Turqouise (0.000, 0.922, 1.000)
+		"bd00ff",	// Violet (0.741, 0.000, 1.000)
+		"ecce87",	// Wheat (0.925, 0.808, 0.529)
+		"f7a58b",	// Peach (0.969, 0.647, 0.545)
+		"bfff81",	// Mint (0.749, 1.000, 0.506)
+		"dbb8eb",	// Lavender (0.859, 0.722, 0.922)
+		"4f5054",	// Coal (0.310, 0.314, 0.333)
+		"ecf0ff",	// Snow (0.925, 0.941, 1.000)
+		"00781e",	// Emerald (0.000, 0.471, 0.118)
+		"a56e34",	// Peanut (0.647, 0.435, 0.204)
+		// Unused (Included for completeness)
+		"2e2d2e",	// Black (0.180, 0.176, 0.180)
+		"2e2d2e",	// Black (0.180, 0.176, 0.180)
+		"2e2d2e",	// Black (0.180, 0.176, 0.180)
+		"2e2d2e"	// Black (0.180, 0.176, 0.180)
+	};
+
+	// Player Properties tab
+
+	for (int i = 0; i < 24; i++) {
+		
+		PlayerRow row;
+
+		auto* number = new QLabel(QString::number(i + 1));
+		number->setAlignment(Qt::AlignCenter);
+
+		std::string name = "Player " + std::to_string(i+1);
+		row.name = new QLineEdit(QString::fromStdString(name));
+		row.name->setEnabled(false);
+
+		row.color = new QLabel;
+		row.color->setStyleSheet(QString("background-color: #%1;").arg(player_colors[i]));
+
+		row.race = new QComboBox;
+		row.race->addItems({ "Human", "Orc", "Undead", "Night Elf", "Selectable" });
+		row.race->setEnabled(false);
+		row.race->setCurrentIndex(i%4);
+
+		row.controller = new QComboBox;
+		row.controller->addItems({ "None", "User", "Computer", "Neutral", "Rescuable" });
+
+		row.fixed_start_position = new QCheckBox;
+		row.fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+		row.fixed_start_position->setEnabled(false);
+
+		ui.playerGrid->addWidget(number, i+1, 0);
+		ui.playerGrid->addWidget(row.name, i+1, 1);
+		ui.playerGrid->addWidget(row.color, i+1, 2);
+		ui.playerGrid->addWidget(row.race, i+1, 3);
+		ui.playerGrid->addWidget(row.controller, i+1, 4);
+		ui.playerGrid->addWidget(row.fixed_start_position, i+1, 5, Qt::AlignHCenter);
+
+		player_rows.push_back(row);
+	}
+
+	ui.playerGrid->setVerticalSpacing(0);
+
+	for (int i = 0; i < map->info.players.size(); i++) {
+		const auto& p = map->info.players[i];
+
+		player_rows[p.internal_number].name->setText(QString::fromUtf8(map->trigger_strings.string(p.name)));
+		player_rows[p.internal_number].name->setEnabled(true);
+
+		switch (p.race) {
+		case PlayerRace::human:
+			player_rows[p.internal_number].race->setCurrentIndex(0);
+			break;
+		case PlayerRace::orc:
+			player_rows[p.internal_number].race->setCurrentIndex(1);
+			break;
+		case PlayerRace::undead:
+			player_rows[p.internal_number].race->setCurrentIndex(2);
+			break;
+		case PlayerRace::night_elf:
+			player_rows[p.internal_number].race->setCurrentIndex(3);
+			break;
+		case PlayerRace::selectable:
+			player_rows[p.internal_number].race->setCurrentIndex(4);
+			break;
+		}
+		player_rows[p.internal_number].race->setEnabled(true);
+		
+
+		switch (p.type) {
+		case PlayerType::human:
+			player_rows[p.internal_number].controller->setCurrentIndex(1);
+			break;
+		case PlayerType::computer:
+			player_rows[p.internal_number].controller->setCurrentIndex(2);
+			break;
+		case PlayerType::neutral:
+			player_rows[p.internal_number].controller->setCurrentIndex(3);
+			break;
+		case PlayerType::rescuable:
+			player_rows[p.internal_number].controller->setCurrentIndex(4);
+			break;
+		}
+
+		if (p.fixed_start_position == 0) {
+			player_rows[p.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+		} else {
+			player_rows[p.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Checked);
+		}
+		player_rows[p.internal_number].fixed_start_position->setEnabled(true);
+	}
+
+	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton *button) {
+		// Restoring Player 1 defaults
+		player_rows[0].name->setText("");
+		player_rows[0].name->setEnabled(true);
+
+		player_rows[0].race->setCurrentIndex(0);
+		player_rows[0].race->setEnabled(true);
+
+		player_rows[0].controller->setCurrentIndex(1);
+
+		player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+		player_rows[0].fixed_start_position->setEnabled(true);
+
+		// Restoring Player 2 - 24 defaults
+		if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole) {
+			for (int i = 1; i < 24; i++) {
+				std::string name = "Player " + std::to_string(i+1);
+				player_rows[i].name->setText(QString::fromStdString(name));
+				player_rows[i].name->setEnabled(false);
+
+				player_rows[i].race->setCurrentIndex(i%4);
+				player_rows[i].race->setEnabled(false);
+
+				player_rows[i].controller->setCurrentIndex(0);
+
+				player_rows[i].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+				player_rows[i].fixed_start_position->setEnabled(false);
+			}
+		}
+	});
+	
+	connect(ui.buttonBox, &QDialogButtonBox::accepted, [&]() {
+		if (save()) {
+			emit accept();
+			close();
+		}
+	});
+
+	connect(ui.buttonBox, &QDialogButtonBox::rejected, [&]() {
+		emit reject();
+		close();
+	});
+
+	for (int player_slot = 0; player_slot < 24; player_slot++) {
+		connect(player_rows[player_slot].controller, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, player_slot](int controllerTypeIndex) {
+			updateController(player_slot, controllerTypeIndex);
+		});
+	}
+
+    show();
+}
+
+
+bool ScenarioInfoEditor::save() const {
+	for (int slot = 0; slot < 24; slot++) {
+		const int controller_type = player_rows[slot].controller->currentIndex();
+
+		int found_index = -1;
+
+		for (int i = 0; i < map->info.players.size(); i++) {
+			if (map->info.players[i].internal_number == slot) {
+				found_index = i;
+				break;
+			}
+		}
+
+		// Controller == None ?
+		if (controller_type == 0) {
+			if (found_index != -1) {
+				map->info.players.erase(map->info.players.begin() + slot);
+			}
+			continue;
+		}
+
+		// Controller is not None and we didn't an existing player
+		// Creating a new player data
+		if (found_index == -1) {
+			auto& new_player = map->info.players.emplace_back();
+			
+			new_player.internal_number = slot;
+			new_player.type = PlayerType::human,
+			new_player.race = PlayerRace::human,
+			new_player.fixed_start_position = 0,
+			new_player.name = "",
+			new_player.starting_position = { 0.f, 0.f },
+			new_player.ally_low_priorities_flags = 0,
+			new_player.ally_high_priorities_flags = 0,
+			new_player.enemy_low_priorities_flags = 0,
+			new_player.enemy_high_priorities_flags = 0,
+
+			found_index = map->info.players.size()-1;
+		}
+
+		auto& p = map->info.players[found_index];
+
+		switch (controller_type) {
+			case 1:
+				p.type = PlayerType::human;
+				break;
+			case 2:
+				p.type = PlayerType::computer;
+				break;
+			case 3:
+				p.type = PlayerType::neutral;
+				break;
+			case 4:
+				p.type = PlayerType::rescuable;
+				break;
+		}
+
+		map->trigger_strings.set_string(p.name, player_rows[slot].name->text().toStdString());
+
+		switch (player_rows[slot].race->currentIndex()) {
+		case 0:
+			p.race = PlayerRace::human;
+			break;
+		case 1:
+			p.race = PlayerRace::orc;
+			break;
+		case 2:
+			p.race = PlayerRace::undead;
+			break;
+		case 3:
+			p.race = PlayerRace::night_elf;
+			break;
+		case 4:
+			p.race = PlayerRace::selectable;
+			break;
+		}
+		
+		p.fixed_start_position = (player_rows[p.internal_number].fixed_start_position->checkState() == Qt::CheckState::Checked) ? 1 : 0;
+	}
+
+	return true;
+}
+
+
+void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex) {
+	if (controllerTypeIndex == 0) {
+		player_rows[slotIndex].name->setEnabled(false);
+		player_rows[slotIndex].race->setEnabled(false);
+		player_rows[slotIndex].fixed_start_position->setEnabled(false);
+	} else {
+		player_rows[slotIndex].name->setEnabled(true);
+		player_rows[slotIndex].race->setEnabled(true);
+		player_rows[slotIndex].fixed_start_position->setEnabled(true);
+	}
+}

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -2,6 +2,7 @@
 
 #include <QMessageBox>
 #include <QPainter>
+#include <cstddef>
 #include <vector>
 #include <string>
 
@@ -101,53 +102,52 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 
 	ui.playerGrid->setVerticalSpacing(0);
 
-	for (int i = 0; i < map->info.players.size(); i++) {
-		const auto& p = map->info.players[i];
+	for (const auto& player: map->info.players) {
 
-		player_rows[p.internal_number].name->setText(QString::fromUtf8(map->trigger_strings.string(p.name)));
-		player_rows[p.internal_number].name->setEnabled(true);
+		player_rows[player.internal_number].name->setText(QString::fromUtf8(map->trigger_strings.string(player.name)));
+		player_rows[player.internal_number].name->setEnabled(true);
 
-		switch (p.race) {
+		switch (player.race) {
 		case PlayerRace::human:
-			player_rows[p.internal_number].race->setCurrentIndex(0);
+			player_rows[player.internal_number].race->setCurrentIndex(0);
 			break;
 		case PlayerRace::orc:
-			player_rows[p.internal_number].race->setCurrentIndex(1);
+			player_rows[player.internal_number].race->setCurrentIndex(1);
 			break;
 		case PlayerRace::undead:
-			player_rows[p.internal_number].race->setCurrentIndex(2);
+			player_rows[player.internal_number].race->setCurrentIndex(2);
 			break;
 		case PlayerRace::night_elf:
-			player_rows[p.internal_number].race->setCurrentIndex(3);
+			player_rows[player.internal_number].race->setCurrentIndex(3);
 			break;
 		case PlayerRace::selectable:
-			player_rows[p.internal_number].race->setCurrentIndex(4);
+			player_rows[player.internal_number].race->setCurrentIndex(4);
 			break;
 		}
-		player_rows[p.internal_number].race->setEnabled(true);
+		player_rows[player.internal_number].race->setEnabled(true);
 		
 
-		switch (p.type) {
+		switch (player.type) {
 		case PlayerType::human:
-			player_rows[p.internal_number].controller->setCurrentIndex(1);
+			player_rows[player.internal_number].controller->setCurrentIndex(1);
 			break;
 		case PlayerType::computer:
-			player_rows[p.internal_number].controller->setCurrentIndex(2);
+			player_rows[player.internal_number].controller->setCurrentIndex(2);
 			break;
 		case PlayerType::neutral:
-			player_rows[p.internal_number].controller->setCurrentIndex(3);
+			player_rows[player.internal_number].controller->setCurrentIndex(3);
 			break;
 		case PlayerType::rescuable:
-			player_rows[p.internal_number].controller->setCurrentIndex(4);
+			player_rows[player.internal_number].controller->setCurrentIndex(4);
 			break;
 		}
 
 		if (p.fixed_start_position == 0) {
-			player_rows[p.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+			player_rows[player.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
 		} else {
-			player_rows[p.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Checked);
+			player_rows[player.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Checked);
 		}
-		player_rows[p.internal_number].fixed_start_position->setEnabled(true);
+		player_rows[player.internal_number].fixed_start_position->setEnabled(true);
 	}
 
 	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton *button) {
@@ -204,7 +204,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 
 
 bool ScenarioInfoEditor::save() const {
-	for (int slot = 0; slot < 24; slot++) {
+	for (size_t slot = 0; slot < 24; slot++) {
 		const int controller_type = player_rows[slot].controller->currentIndex();
 
 		int found_index = -1;
@@ -288,12 +288,12 @@ bool ScenarioInfoEditor::save() const {
 
 
 void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex) {
-	// Is NOT controller type Human ?
+	// Is controller type NOT Human ?
 	if (controllerTypeIndex != 1) {
-		// Is there any other controller type Human player ?
+		// Is there any other Human controller type ?
 		bool found_human = false;
-		for (int i = 0; i < 24; i++) {
-			if (player_rows[i].controller->currentIndex() == 1) {
+		for (const auto& player : player_rows) {
+			if (player.controller->currentIndex() == 1) {
 				found_human = true;
 				break;
 			}

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -142,7 +142,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 			break;
 		}
 
-		if (p.fixed_start_position == 0) {
+		if (player.fixed_start_position == 0) {
 			player_rows[player.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
 		} else {
 			player_rows[player.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Checked);

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -79,7 +79,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		row.name->setEnabled(false);
 
 		row.color = new QLabel;
-		row.color->setStyleSheet(QString("background-color: #%1;").arg(player_colors[i]));
+		row.color->setStyleSheet(QString("background-color: #%1; margin: 2px 0px;").arg(player_colors[i]));
 
 		row.race = new QComboBox;
 		row.race->addItems({ "Human", "Orc", "Undead", "Night Elf", "Selectable" });
@@ -151,32 +151,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 
 	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton *button) {
 		if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole) {
-			// Restoring Player 1 defaults
-			player_rows[0].controller->setCurrentIndex(1);
-
-			player_rows[0].name->setText("Player 1");
-			player_rows[0].name->setEnabled(true);
-
-			player_rows[0].race->setCurrentIndex(0);
-			player_rows[0].race->setEnabled(true);
-
-			player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
-			player_rows[0].fixed_start_position->setEnabled(true);
-
-			// Restoring Player 2 - 24 defaults
-			for (int i = 1; i < 24; i++) {
-				player_rows[i].controller->setCurrentIndex(0);
-
-				std::string name = "Player " + std::to_string(i+1);
-				player_rows[i].name->setText(QString::fromStdString(name));
-				player_rows[i].name->setEnabled(false);
-
-				player_rows[i].race->setCurrentIndex(i%4);
-				player_rows[i].race->setEnabled(false);
-
-				player_rows[i].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
-				player_rows[i].fixed_start_position->setEnabled(false);
-			}
+			restoreDefaults();
 		}
 	});
 	
@@ -245,18 +220,18 @@ bool ScenarioInfoEditor::save() const {
 		auto& p = map->info.players[found_index];
 
 		switch (controller_type) {
-			case 1:
-				p.type = PlayerType::human;
-				break;
-			case 2:
-				p.type = PlayerType::computer;
-				break;
-			case 3:
-				p.type = PlayerType::neutral;
-				break;
-			case 4:
-				p.type = PlayerType::rescuable;
-				break;
+		case 1:
+			p.type = PlayerType::human;
+			break;
+		case 2:
+			p.type = PlayerType::computer;
+			break;
+		case 3:
+			p.type = PlayerType::neutral;
+			break;
+		case 4:
+			p.type = PlayerType::rescuable;
+			break;
 		}
 
 		map->trigger_strings.set_string(p.name, player_rows[slot].name->text().toStdString());
@@ -317,5 +292,54 @@ void ScenarioInfoEditor::updateController(int slotIndex, int controllerTypeIndex
 		player_rows[slotIndex].name->setEnabled(true);
 		player_rows[slotIndex].race->setEnabled(true);
 		player_rows[slotIndex].fixed_start_position->setEnabled(true);
+	}
+}
+
+void ScenarioInfoEditor::restoreDefaults() {
+	int choice = QMessageBox::question(
+		this,
+		"Do you want to restore defaults?",
+		"Are you sure you want to restore default values?",
+		QMessageBox::Yes | QMessageBox::No,
+		QMessageBox::No
+	);
+
+	if (choice == QMessageBox::No) {
+		return;
+	}
+
+	switch (ui.tabs->currentIndex()) {
+	case 0:
+		restorePlayerProperties();
+		break;
+	}
+}
+
+void ScenarioInfoEditor::restorePlayerProperties() {
+	// Restoring Player 1 defaults
+	player_rows[0].controller->setCurrentIndex(1);
+
+	player_rows[0].name->setText("Player 1");
+	player_rows[0].name->setEnabled(true);
+
+	player_rows[0].race->setCurrentIndex(0);
+	player_rows[0].race->setEnabled(true);
+
+	player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+	player_rows[0].fixed_start_position->setEnabled(true);
+
+	// Restoring Player 2 - 24 defaults
+	for (int i = 1; i < 24; i++) {
+		player_rows[i].controller->setCurrentIndex(0);
+
+		std::string name = "Player " + std::to_string(i+1);
+		player_rows[i].name->setText(QString::fromStdString(name));
+		player_rows[i].name->setEnabled(false);
+
+		player_rows[i].race->setCurrentIndex(i%4);
+		player_rows[i].race->setEnabled(false);
+
+		player_rows[i].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
+		player_rows[i].fixed_start_position->setEnabled(false);
 	}
 }

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -71,6 +71,9 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		auto* number = new QLabel(QString::number(i + 1));
 		number->setAlignment(Qt::AlignCenter);
 
+		row.controller = new QComboBox;
+		row.controller->addItems({ "None", "User", "Computer", "Neutral", "Rescuable" });
+
 		std::string name = "Player " + std::to_string(i+1);
 		row.name = new QLineEdit(QString::fromStdString(name));
 		row.name->setEnabled(false);
@@ -83,18 +86,15 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		row.race->setEnabled(false);
 		row.race->setCurrentIndex(i%4);
 
-		row.controller = new QComboBox;
-		row.controller->addItems({ "None", "User", "Computer", "Neutral", "Rescuable" });
-
 		row.fixed_start_position = new QCheckBox;
 		row.fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
 		row.fixed_start_position->setEnabled(false);
 
 		ui.playerGrid->addWidget(number, i+1, 0);
-		ui.playerGrid->addWidget(row.name, i+1, 1);
-		ui.playerGrid->addWidget(row.color, i+1, 2);
-		ui.playerGrid->addWidget(row.race, i+1, 3);
-		ui.playerGrid->addWidget(row.controller, i+1, 4);
+		ui.playerGrid->addWidget(row.controller, i+1, 1);
+		ui.playerGrid->addWidget(row.name, i+1, 2);
+		ui.playerGrid->addWidget(row.color, i+1, 3);
+		ui.playerGrid->addWidget(row.race, i+1, 4);
 		ui.playerGrid->addWidget(row.fixed_start_position, i+1, 5, Qt::AlignHCenter);
 
 		player_rows.push_back(row);
@@ -103,6 +103,21 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 	ui.playerGrid->setVerticalSpacing(0);
 
 	for (const auto& player: map->info.players) {
+		
+		switch (player.type) {
+		case PlayerType::human:
+			player_rows[player.internal_number].controller->setCurrentIndex(1);
+			break;
+		case PlayerType::computer:
+			player_rows[player.internal_number].controller->setCurrentIndex(2);
+			break;
+		case PlayerType::neutral:
+			player_rows[player.internal_number].controller->setCurrentIndex(3);
+			break;
+		case PlayerType::rescuable:
+			player_rows[player.internal_number].controller->setCurrentIndex(4);
+			break;
+		}
 
 		player_rows[player.internal_number].name->setText(QString::fromUtf8(map->trigger_strings.string(player.name)));
 		player_rows[player.internal_number].name->setEnabled(true);
@@ -125,22 +140,6 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 			break;
 		}
 		player_rows[player.internal_number].race->setEnabled(true);
-		
-
-		switch (player.type) {
-		case PlayerType::human:
-			player_rows[player.internal_number].controller->setCurrentIndex(1);
-			break;
-		case PlayerType::computer:
-			player_rows[player.internal_number].controller->setCurrentIndex(2);
-			break;
-		case PlayerType::neutral:
-			player_rows[player.internal_number].controller->setCurrentIndex(3);
-			break;
-		case PlayerType::rescuable:
-			player_rows[player.internal_number].controller->setCurrentIndex(4);
-			break;
-		}
 
 		if (player.fixed_start_position == 0) {
 			player_rows[player.internal_number].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
@@ -153,27 +152,27 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 	connect(ui.buttonBox, &QDialogButtonBox::clicked, this, [this](QAbstractButton *button) {
 		if (ui.buttonBox->buttonRole(button) == QDialogButtonBox::ResetRole) {
 			// Restoring Player 1 defaults
-			player_rows[0].name->setText("");
+			player_rows[0].controller->setCurrentIndex(1);
+
+			player_rows[0].name->setText("Player 1");
 			player_rows[0].name->setEnabled(true);
 
 			player_rows[0].race->setCurrentIndex(0);
 			player_rows[0].race->setEnabled(true);
-
-			player_rows[0].controller->setCurrentIndex(1);
 
 			player_rows[0].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
 			player_rows[0].fixed_start_position->setEnabled(true);
 
 			// Restoring Player 2 - 24 defaults
 			for (int i = 1; i < 24; i++) {
+				player_rows[i].controller->setCurrentIndex(0);
+
 				std::string name = "Player " + std::to_string(i+1);
 				player_rows[i].name->setText(QString::fromStdString(name));
 				player_rows[i].name->setEnabled(false);
 
 				player_rows[i].race->setCurrentIndex(i%4);
 				player_rows[i].race->setEnabled(false);
-
-				player_rows[i].controller->setCurrentIndex(0);
 
 				player_rows[i].fixed_start_position->setCheckState(Qt::CheckState::Unchecked);
 				player_rows[i].fixed_start_position->setEnabled(false);

--- a/src/menus/scenario_info_editor.cpp
+++ b/src/menus/scenario_info_editor.cpp
@@ -64,7 +64,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 
 	// Player Properties tab
 
-	for (int i = 0; i < 24; i++) {
+	for (size_t i = 0; i < 24; i++) {
 		
 		PlayerRow row;
 
@@ -167,7 +167,7 @@ ScenarioInfoEditor::ScenarioInfoEditor(QWidget* parent) : QDialog(parent) {
 		close();
 	});
 
-	for (int player_slot = 0; player_slot < 24; player_slot++) {
+	for (size_t player_slot = 0; player_slot < 24; player_slot++) {
 		connect(player_rows[player_slot].controller, QOverload<int>::of(&QComboBox::currentIndexChanged), this, [this, player_slot](int controllerTypeIndex) {
 			updateController(player_slot, controllerTypeIndex);
 		});
@@ -183,7 +183,7 @@ bool ScenarioInfoEditor::save() const {
 
 		int found_index = -1;
 
-		for (int i = 0; i < map->info.players.size(); i++) {
+		for (size_t i = 0; i < map->info.players.size(); i++) {
 			if (map->info.players[i].internal_number == slot) {
 				found_index = i;
 				break;
@@ -326,7 +326,7 @@ void ScenarioInfoEditor::restorePlayerProperties() {
 	player_rows[0].fixed_start_position->setEnabled(true);
 
 	// Restoring Player 2 - 24 defaults
-	for (int i = 1; i < 24; i++) {
+	for (size_t i = 1; i < 24; i++) {
 		player_rows[i].controller->setCurrentIndex(ControllerType::none);
 
 		const std::string name = "Player " + std::to_string(i+1);

--- a/src/menus/scenario_info_editor.h
+++ b/src/menus/scenario_info_editor.h
@@ -30,5 +30,7 @@ class ScenarioInfoEditor: public QDialog {
 
   private:
 	void updateController(int slotIndex, int controllerTypeIndex);
+	void restoreDefaults();
+	void restorePlayerProperties();
     
 };

--- a/src/menus/scenario_info_editor.h
+++ b/src/menus/scenario_info_editor.h
@@ -34,6 +34,5 @@ class ScenarioInfoEditor: public QDialog {
 
   private:
 	void updateController(int slotIndex, int controllerTypeIndex);
-	void updateRace(int slotIndex, int raceTypeIndex);
     
 };

--- a/src/menus/scenario_info_editor.h
+++ b/src/menus/scenario_info_editor.h
@@ -1,9 +1,5 @@
 #pragma once
 
-#include <glm/glm.hpp>
-#include <glm/gtc/matrix_transform.hpp>
-#include <glm/gtc/quaternion.hpp>
-
 #include <QDialog>
 #include <QLineEdit>
 #include <QLabel>

--- a/src/menus/scenario_info_editor.h
+++ b/src/menus/scenario_info_editor.h
@@ -33,4 +33,13 @@ class ScenarioInfoEditor: public QDialog {
 	void restoreDefaults();
 	void restorePlayerProperties();
     
+	// Private redefinition of Controller type for mapping dropdown indices
+	// PlayerType (equivalent enum) lacks the none type
+	enum ControllerType {
+		none,
+		user,
+		computer,
+		neutral,
+		rescuable
+	};
 };

--- a/src/menus/scenario_info_editor.h
+++ b/src/menus/scenario_info_editor.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <glm/glm.hpp>
+#include <glm/gtc/matrix_transform.hpp>
+#include <glm/gtc/quaternion.hpp>
+
+#include <QDialog>
+#include <QLineEdit>
+#include <QLabel>
+#include <QComboBox>
+#include <QCheckBox>
+
+#include "ui_scenario_info_editor.h"
+
+struct PlayerRow {
+	QLineEdit* name;
+	QLabel* color;
+	QComboBox* race;
+	QComboBox* controller;
+	QCheckBox* fixed_start_position;
+};
+
+class ScenarioInfoEditor: public QDialog {
+	Q_OBJECT
+
+  public:
+	ScenarioInfoEditor(QWidget* parent = nullptr);
+
+	Ui::ScenarioInfoEditor ui;
+	
+	std::vector<PlayerRow> player_rows;
+
+	bool save() const;
+
+  private:
+	void updateController(int slotIndex, int controllerTypeIndex);
+	void updateRace(int slotIndex, int raceTypeIndex);
+    
+};

--- a/src/menus/scenario_info_editor.ui
+++ b/src/menus/scenario_info_editor.ui
@@ -1,0 +1,223 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>ScenarioInfoEditor</class>
+ <widget class="QDialog" name="ScenarioInfoEditor">
+  <property name="windowModality">
+   <enum>Qt::WindowModality::ApplicationModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>606</width>
+    <height>556</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ScenarioInfoEditor</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <layout class="QVBoxLayout" name="verticalLayout_1">
+     <item>
+      <widget class="QTabWidget" name="tabs">
+       <property name="currentIndex">
+        <number>0</number>
+       </property>
+       <property name="usesScrollButtons">
+        <bool>false</bool>
+       </property>
+       <widget class="QWidget" name="tab">
+        <attribute name="title">
+         <string>Players</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <layout class="QGridLayout" name="playerGrid">
+           <item row="0" column="5">
+            <widget class="QLabel" name="label_5">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="layoutDirection">
+              <enum>Qt::LayoutDirection::LeftToRight</enum>
+             </property>
+             <property name="text">
+              <string>Fixed Start&lt;br&gt;Location</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="0">
+            <widget class="QLabel" name="label_2">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>#</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_7">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Player Name</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="4">
+            <widget class="QLabel" name="label_6">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Controller</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_8">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Race</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_9">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Color</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
+       </widget>
+       <widget class="QWidget" name="tab_2">
+        <attribute name="title">
+         <string>Ally Priorities</string>
+        </attribute>
+        <layout class="QVBoxLayout" name="formLayout_3"/>
+       </widget>
+       <widget class="QWidget" name="tab_3">
+        <attribute name="title">
+         <string>Forces</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="tab_4">
+        <attribute name="title">
+         <string>Techtree</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="tab_5">
+        <attribute name="title">
+         <string>Abilities</string>
+        </attribute>
+       </widget>
+       <widget class="QWidget" name="tab_6">
+        <attribute name="title">
+         <string>Upgrades</string>
+        </attribute>
+       </widget>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDialogButtonBox" name="buttonBox">
+       <property name="standardButtons">
+        <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok|QDialogButtonBox::StandardButton::RestoreDefaults</set>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <layout class="QHBoxLayout" name="horizontalLayout"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+ <buttongroups>
+  <buttongroup name="loadingScreenGraphicGroup"/>
+ </buttongroups>
+</ui>

--- a/src/menus/scenario_info_editor.ui
+++ b/src/menus/scenario_info_editor.ui
@@ -34,6 +34,28 @@
         <layout class="QVBoxLayout" name="verticalLayout_2">
          <item>
           <layout class="QGridLayout" name="playerGrid">
+           <item row="0" column="1">
+            <widget class="QLabel" name="label_7">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Controller</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
            <item row="0" column="5">
             <widget class="QLabel" name="label_5">
              <property name="minimumSize">
@@ -81,8 +103,30 @@
              </property>
             </widget>
            </item>
-           <item row="0" column="1">
-            <widget class="QLabel" name="label_7">
+           <item row="0" column="3">
+            <widget class="QLabel" name="label_8">
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="text">
+              <string>Color</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignmentFlag::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="0" column="2">
+            <widget class="QLabel" name="label_9">
              <property name="minimumSize">
               <size>
                <width>0</width>
@@ -118,51 +162,7 @@
               </size>
              </property>
              <property name="text">
-              <string>Controller</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="3">
-            <widget class="QLabel" name="label_8">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
               <string>Race</string>
-             </property>
-             <property name="alignment">
-              <set>Qt::AlignmentFlag::AlignCenter</set>
-             </property>
-            </widget>
-           </item>
-           <item row="0" column="2">
-            <widget class="QLabel" name="label_9">
-             <property name="minimumSize">
-              <size>
-               <width>0</width>
-               <height>0</height>
-              </size>
-             </property>
-             <property name="maximumSize">
-              <size>
-               <width>16777215</width>
-               <height>16777215</height>
-              </size>
-             </property>
-             <property name="text">
-              <string>Color</string>
              </property>
              <property name="alignment">
               <set>Qt::AlignmentFlag::AlignCenter</set>
@@ -177,27 +177,86 @@
         <attribute name="title">
          <string>Ally Priorities</string>
         </attribute>
-        <layout class="QVBoxLayout" name="formLayout_3"/>
+        <layout class="QVBoxLayout" name="verticalLayout_2">
+         <item>
+          <widget class="QLabel" name="label">
+           <property name="text">
+            <string>This feature is currently unimplemented.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="tab_3">
         <attribute name="title">
          <string>Forces</string>
         </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_3">
+         <item>
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>This feature is currently unimplemented.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="tab_4">
         <attribute name="title">
          <string>Techtree</string>
         </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_4">
+         <item>
+          <widget class="QLabel" name="label_4">
+           <property name="text">
+            <string>This feature is currently unimplemented.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="tab_5">
         <attribute name="title">
          <string>Abilities</string>
         </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_5">
+         <item>
+          <widget class="QLabel" name="label_10">
+           <property name="text">
+            <string>This feature is currently unimplemented.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="tab_6">
         <attribute name="title">
          <string>Upgrades</string>
         </attribute>
+        <layout class="QVBoxLayout" name="verticalLayout_6">
+         <item>
+          <widget class="QLabel" name="label_11">
+           <property name="text">
+            <string>This feature is currently unimplemented.</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignCenter</set>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </widget>
       </widget>
      </item>
@@ -217,7 +276,4 @@
  </widget>
  <resources/>
  <connections/>
- <buttongroups>
-  <buttongroup name="loadingScreenGraphicGroup"/>
- </buttongroups>
 </ui>


### PR DESCRIPTION
New features
- Added ScenarioInfoEditor with six tabs (Players, Ally Priorities, Forces, Techtree, Abilities, Upgrades)
- Added buttons for each of these tabs into a Scenario section which sits next to the Map section
- Implemented Player Properties (Players tab in ScenarioInfoEditor)
<img width="379" height="465" alt="player_properties" src="https://github.com/user-attachments/assets/7d9d364d-1e13-4ff5-b1db-24ba303ce2cf" />

Bugfixes
- Fixed Loading Screen opening Options tab and Options opening Size and Camera Bounds tab

### Temporary decisions
There are no player colours defined in the code outside of shaders. Because of that, their hex codes are temporarily defined in src/menus/scenario_info_editor.cpp. In the future they should be exposed to other parts of the code.

### Future work
- Implementing the remaining ScenarioInfoEditor tabs (Ally Priorities, Forces, Techtree, Abilities, Upgrades)